### PR TITLE
KSv1-10: lock free and algo

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -1,162 +1,188 @@
 # Internals
 
+This document explains how the current v1 cache core is put together with a focus on ownership, concurrency boundaries and policy behavior. The public API is covered in `README.md`.
+
 ## Package Layout
 
-The root `kioshun` package implements a generic in-memory cache:
+The root `kioshun` package contains the generic cache:
 
-- `cache.go`: public cache API, configuration, sharding, reads, stats, cleanup.
+- `cache.go`: public API, construction, sharding, reads, stats, cleanup.
 - `writes.go`: queued writes, synchronous mutation ordering, barriers, workers.
-- `shard.go`: per-shard state, list maintenance, item removal, TTL cleanup.
-- `eviction.go`: LRU, LFU, and FIFO eviction adapters.
+- `shard.go`: per-shard state, item removal, read-sample draining, TTL cleanup.
+- `htable.go`: per-shard open-addressing table with lock-free lookups.
+- `item.go`: cache entry metadata and immutable reader-visible fields.
+- `evict.go`: removal reasons and removal/eviction listener options.
+- `evictor.go`: LRU, LFU, and FIFO eviction adapters.
 - `lfu.go`: exact LFU frequency bucket list.
 - `sieve.go`, `sketch.go`, `ghost.go`, `read_buffer.go`: SieveTinyLFU policy.
 - `queue.go`: bounded per-shard MPSC write queue.
-- `hash.go`, `fnv.go`: type-specialized hashing.
+- `pid.go`: best-effort P id lookup used for striped read buffers and stats.
+- `internal/keyhash`: type-specialized hashing.
 - `manager.go`: named cache registry and global manager helpers.
 
-The `httpcache` package builds HTTP response caching middleware on top of the
-root cache:
+The `httpcache` package layers HTTP response caching on top:
 
-- `httpcache/config.go`: HTTP middleware configuration and default resolution.
+- `httpcache/config.go`: middleware configuration and default resolution.
 - `httpcache/middleware.go`: handler wrapping, response capture, policies, keys.
 - `httpcache/pattern.go`: path-segment trie indexing cached keys for pattern
   invalidation, kept in sync by the cache's removal listener.
 
 ## Core Data Model
 
-`Cache[K, V]` is a sharded cache. Each shard owns:
+`Cache[K, V]` is split into shards. A shard is the unit of ownership for table state, policy state, queued writes, and capacity accounting. Each shard keeps:
 
-- `data map[K]*cacheItem[K,V]`
-- one `sync.RWMutex`
-- a bounded write queue and one worker goroutine
-- an LRU-style intrusive list for LRU, FIFO, and general item unlinking
-- an LFU bucket list when `EvictionPolicy == LFU`
-- SieveTinyLFU policy state when `EvictionPolicy == SieveTinyLFU` and the shard is bounded
-- per-shard stats counters
+- one `htable[K,V]` for key/value storage
+- one `sync.RWMutex` for writers, scans, expiration removals, and non-Sieve policy reads
+- a bounded MPSC write queue and one write-worker goroutine
+- a `drainMu` single-consumer token shared by the worker, synchronous mutators, miss-path catch-up and opportunistic inline writes
+- an LRU-style list for LRU, FIFO, and generic unlinking
+- an exact LFU bucket list when `EvictionPolicy == LFU`
+- SieveTinyLFU state and a read-sample buffer when the policy is bounded
+- atomic resident size/cost counters
+- optional removal listener staging buffers
 
-`cacheItem` stores the value and all policy metadata in one pooled object:
+Bounded SieveTinyLFU reads do not take the shard lock. Writers still serialize through the lock, but readers can probe the table while a writer is active.
+That design drives the item lifetime rules:
 
-- `expireTime`: absolute Unix nanoseconds; `0` means no expiration.
-- `lastAccess`: updated by LRU/LFU/Sieve reads and writes where relevant.
-- `prev` and `next`: intrusive list pointers.
-- `lfuFreq`: exact LFU counter for the LFU policy.
-- `sieveQ`, `queue`, `reuse`, `visited`: SieveTinyLFU queue and SIEVE metadata.
-- `hash` and `tag`: cached hash and compact non-zero tag for ghost entries.
-- `key`: original map key so eviction can delete from `data`.
+- Reader-visible item fields (`key`, `hash`, `value`, `expireTime`) are written before publication and are never mutated after publication.
+- SieveTinyLFU updates publish a fresh item instead of mutating the old one.
+- An evicted item may still be held by a reader, so cache items are not returned to `sync.Pool`; the Go GC owns item reclamation.
+- Only synchronous write waiters are pooled.
 
-Items and synchronous write waiters are reused through `sync.Pool`. Releasing an
-item resets the whole struct before it returns to the pool.
+`cacheItem` carries the stored value plus the metadata needed by the active policy:
+
+- `value`, `key`, `hash`, `expireTime`: immutable while visible to lock-free readers.
+- `cost`: weigher-reported cost, updated only on the serialized write path.
+- `prev`, `next`: intrusive list/queue links.
+- `queue`, `queueOwner`: Sieve queue identity for probation/main ownership.
+- `reuse`, `visited`: Sieve reuse state. Readers set `visited` atomically; the maintenance path consumes and clears it.
+- `unpublished`: Sieve insert candidates can live in policy queues before they are published into the table.
 
 ## Configuration
 
 `DefaultConfig()` uses:
 
 - `MaxSize = 10000`
+- `MaxCost = 0`
 - `ShardCount = 0`, meaning auto-detect
 - `CleanupInterval = 5 * time.Minute`
 - `DefaultTTL = 30 * time.Minute`
 - `EvictionPolicy = SieveTinyLFU`
 - `StatsEnabled = false`
-- `ProbationRatio = 10`
+- `ProbationRatio = 1`
 - `GhostRatio = 100`
+- `CostAdmission = CostAdmissionFrequency`
 - `WriteBufferSize = 1024`
 - `WriteBatchSize = 64`
 
-`New` validates the config, resolves `DefaultEvictionPolicy` to
-`SieveTinyLFU`, and fills zero write queue settings with their defaults.
+`New` validates the config, resolves `DefaultEvictionPolicy` to `SieveTinyLFU` and fills in default write queue settings when they are left as zero.
 
-Shard count is rounded to a power of two because shard lookup is
-`hash & shardMask`. When `ShardCount <= 0`, the cache starts with
-`runtime.NumCPU() * 4`, capped at 256. For bounded caches, the shard count is
-also capped so small `MaxSize` values do not create zero-capacity shards. The
-total capacity is distributed exactly: each shard gets `MaxSize / shards`, and
-the first `MaxSize % shards` shards get one extra slot.
+A zero `ShardCount` lets the cache choose a count from the machine: it starts at `runtime.NumCPU() * 4` and caps that at 256. The final count is rounded to a
+power of two so shard lookup is just `hash & shardMask`. For bounded caches, `New` also caps the count so tiny `MaxSize` or `MaxCost` values do not create
+empty shards. `MaxSize` is split exactly across shards: every shard gets `MaxSize / shards`, and the first `MaxSize % shards` shards get one extra slot.
 
-`MaxSize == 0` means unlimited capacity. In that mode SieveTinyLFU policy state
-is not allocated, because no eviction or admission decision is needed.
+`MaxSize == 0` means entries are unlimited. In that mode SieveTinyLFU has no eviction or admission work to do, so the per-shard Sieve state is not allocated.
+A SieveTinyLFU cache with `MaxCost > 0` must also have `MaxSize > 0`; the policy needs a bounded resident entry set to size its queues and sketch.
+
+`MaxCost` adds a weighted resident budget. The budget is distributed per shard and `WithWeigher` supplies item cost. With weighted SieveTinyLFU:
+
+- `CostAdmissionFrequency` compares TinyLFU frequency only.
+- `CostAdmissionBalanced` compares frequency divided by `sqrt(cost)`.
+- `CostAdmissionDensity` compares frequency divided by `cost`.
 
 ## Hashing
 
-`internal/keyhash.New[K]` selects a hash function once per cache type:
+`internal/keyhash.New[K]` picks a hash function once for the key type:
 
 - strings use the Go runtime `memhash` backend by default
-- builds with `-tags kioshun_purego` use FNV-1a for strings of length `<= 8`
-  and a local `xxHash64(seed=0)` implementation for longer strings
-- integer-like keys are read directly and avalanched with xxHash64's finalizer
+- builds with `-tags kioshun_purego` use FNV-1a for strings of length `<= 8` and a local `xxHash64(seed=0)` implementation for longer strings
+- integer-like keys are read directly and avalanched with the xxHash64 finalizer
 - other comparable keys fall back to `fmt.Sprintf("%v", key)` and hash that string
 
-The default string hasher uses `unsafe` plus `go:linkname` to call the Go
-runtime's `memhash`. It is intended for maximum throughput and only reads string
-bytes so it should be safe but it depends on a runtime internal symbol.
-If that tradeoff is not acceptable for your environment and you would like to skip using linkname,
-build with `-tags kioshun_purego` to use pure Go string backend instead.
+The default string path uses `unsafe` plus `go:linkname` to call `runtime.memhash`. The call only reads string bytes and does not keep the
+pointer, but it does depend on a runtime internal symbol. Build with `-tags kioshun_purego` when that tradeoff is not acceptable.
 
-The hash selects the shard by `hash & shardMask`. The map still stores full keys,
-so hash collisions affect distribution only, not key equality.
+The hash selects a shard by `hash & shardMask`. The table still compares full keys on tag matches, so hash collisions affect distribution and probe length not key equality.
 
-SieveTinyLFU ghost entries use `(hash, tag)`, where `tag` is a non-zero `uint16`
-derived from an avalanched salted hash. The tag reduces false ghost hits without
-storing full keys in the ghost queue.
+## Hash Table
+
+Each shard has a single-writer, multi-reader open-addressing table. Readers call `lookup` without taking a lock:
+
+1. Snapshot the current slot array with an atomic pointer load.
+2. Linear probe a dense array of `{tag, item}` cells.
+3. Stop on tag `0` (empty), continue past tag `1` (tombstone), and dereference
+   the item pointer only on a matching normalized hash tag.
+
+The table relies on a strict publication order:
+
+- stores write the item pointer before publishing the tag
+- removals write the tombstone tag before clearing the item pointer
+- rehash and clear publish a fresh slot array atomically
+
+Writers are serialized by the shard lock, so table metadata like `live` and `tombs` is writer-only. A reader may still be walking an old table snapshot, or
+holding an old item, after a writer has removed it. That is safe because both the old table array and the old item remain reachable to the GC until the reader is done.
+
+Sieve inserts use a two-step table path. `probe` either swaps an existing key to a fresh immutable item, or returns a cursor where a new candidate could be
+published. New candidates run admission before they enter the table. A rejected candidate was never visible to readers and leaves no tombstone. An admitted
+candidate is published at the captured cursor.
 
 ## TTL And Expiration
 
-`Set` and `SetAsync` translate TTLs before enqueueing:
+`Set` and `SetAsync` normalize TTLs before they reach the mutation path:
 
 - `DefaultExpiration` (`0`) uses `Config.DefaultTTL`
 - positive TTLs become an absolute `expireTime`
 - `NoExpiration` (`-1`) results in `expireTime == 0`
 
-Current code treats any other non-positive effective TTL as no expiration.
+Any other non-positive effective TTL is treated as no expiration.
 
-Expired items can be removed by:
+Expired items leave the cache through three paths:
 
 - `Get`, when it encounters an expired item
-- `Exists`, which uses a write lock and removes if expired
+- `Exists`, which takes the write lock when removal is needed
 - `Cleanup`, either called manually or by the cleanup worker
 
-`Keys` returns a point-in-time snapshot of non-expired keys, but it does not
-remove expired entries. `SetWithCallback` schedules a timer after commit and
-fires only if the item still exists and is expired when the timer wakes; cleanup
-is still responsible for removing the item.
+`Keys` returns a point-in-time snapshot of non-expired keys. It does not clean up expired entries while scanning. `SetWithCallback` schedules its timer after
+the write commits, then re-checks the item when the timer wakes. The callback fires only if that same key still exists and is expired; cleanup still owns
+actual removal.
 
-### Removal Listener
+## Removal Listener
 
-`WithOnRemove` registers a listener invoked once for every key that leaves the
-cache through capacity eviction, SieveTinyLFU admission rejection, TTL expiration
-or `Delete`. Each notification includes a `RemovalReason`. `WithOnEvict`
-registers a narrower listener for capacity evictions only. Neither listener is
-called for `Clear` or when an existing key's value is replaced. To keep listeners
-off the hot path, the removal paths (`dropItem` and `cleanup`) stage only the
-requested `(key, value, reason)` in a per-shard buffer under the shard
-lock, and a dedicated worker drains the buffers and runs listeners holding no
-shard lock - so listeners may call back into the cache. When no listener is
-configured no buffer is allocated and the worker is never started. Delivery is
-asynchronous, so consumers that maintain a secondary index (such as the httpcache
-pattern index) must tolerate notifications that arrive after a key has been
-reinserted.
+`WithOnRemove` installs a listener for keys that leave the cache through capacity eviction, SieveTinyLFU admission rejection, TTL expiration, or
+`Delete`. Each notification includes a `RemovalReason`. `WithOnEvict` is the narrower hook for capacity evictions only.
+
+Listeners are not called for `Clear`, and they are not called when an existing key is replaced. Removal paths only stage `(key, value, reason)` in a per-shard
+buffer while holding the shard lock. A dedicated worker drains those buffers and calls listeners without holding shard locks, so listeners may call back into the
+cache. If no listener is configured, no buffer or worker is allocated. Delivery is asynchronous, so secondary indexes must handle a notification arriving after
+the same key has already been inserted again.
 
 ## Write Path
 
-Every shard has a bounded multi-producer, single-consumer ring queue. Producers
-claim slots with CAS on `head`; the shard worker owns `tail`. Each cell has a
-sequence number so the queue can distinguish empty, published, and freed slots
-across ring laps. The ring size is rounded to a power of two and is at least 2.
+Every shard has a bounded multi-producer, single-consumer ring queue. Producers claim slots with CAS on `head`; the shard worker owns `tail`. Sequence numbers
+on each cell distinguish free, published, and stale slots across ring laps. The ring size is rounded to a power of two and is never smaller than 2.
 
-`SetAsync` only enqueues. A nil error means the command was accepted, not that it
-has committed. Call `Sync` when committed visibility is required.
+`SetAsync` is the fast write API. It tries the cheapest path first: apply the write inline when the shard is completely idle.
 
-`Set`, `SetWithCallback`, and `Delete` use the synchronous mutation path:
+1. `drainMu.TryLock()` succeeds.
+2. The write queue is quiescent.
+3. `s.mu.TryLock()` succeeds.
 
-1. Take the shard's `drainMu`, which is the single-consumer token for that shard.
-2. Drain queued writes accepted before this mutation.
-3. Take the shard write lock.
-4. Apply the mutation directly.
-5. Release locks and schedule callbacks outside the shard lock.
+The inline path drains read samples before applying the write under the shard lock. That keeps SieveTinyLFU admission consistent with what the worker would
+have done. If any `TryLock` or quiescence check fails, `SetAsync` falls back to the queue. A nil error means the write was accepted; it may already be visible,
+or it may still be waiting for the worker. Call `Sync` when committed visibility matters.
 
-That preserves per-shard ordering while avoiding a worker round trip for strict
-read-after-write operations.
+`Set`, `SetWithCallback`, and `Delete` take the ordered synchronous path:
 
-Shard workers wait on a coalesced `wake` channel. On wake they:
+1. Check that the cache is open.
+2. Take `drainMu`, the shard's single-consumer token.
+3. Drain queued writes accepted before this mutation.
+4. Take the shard write lock.
+5. Apply the mutation directly.
+6. Release locks and schedule callbacks outside the shard lock.
+
+This preserves per-shard ordering and gives `Set` immediate read-after-write visibility.
+
+Shard workers sleep on a coalesced `wake` channel. Each wake runs this sequence:
 
 1. Drain buffered SieveTinyLFU read samples into the sketch.
 2. Dequeue up to `WriteBatchSize` commands.
@@ -164,35 +190,32 @@ Shard workers wait on a coalesced `wake` channel. On wake they:
 4. Acknowledge commands that carry result channels.
 5. Drain read samples again between batches.
 
-`Sync`, `Clear`, and shutdown use barrier commands. A barrier enqueued to every
-shard is acknowledged only after all earlier commands for that shard have been
-applied. `Close` marks the cache closed, flushes accepted writes, closes
-`closeCh`, waits for workers, and clears all shards. Producers blocked on a full
+`Sync`, `Clear`, and shutdown use barrier commands. A barrier sent to every shard is acknowledged only after earlier commands on that shard have been
+applied. `Close` marks the cache closed, flushes accepted writes, closes `closeCh`, waits for workers, and clears all shards. Producers blocked on a full
 queue wake through `closeCh` and return `ErrCacheClosed`.
 
 ## Read Path
 
-All reads return misses after the cache is closed.
+After `Close`, reads return misses.
 
-For LRU and LFU, `Get` takes the shard write lock because the read mutates policy
-metadata. LRU moves the item to the list head. LFU increments the exact frequency
-bucket and updates `lastAccess`.
+For LRU and LFU, `Get` takes the shard write lock because a read changes policy state. LRU moves the item to the list head. LFU increments the exact frequency bucket.
 
-For FIFO, `Get` takes the read lock unless it has to remove an expired item. FIFO
-does not update list position on access.
+For FIFO, `Get` takes the read lock unless it has to remove an expired item. FIFO does not update list position on access.
 
-For bounded SieveTinyLFU, `Get` first tries `TryRLock`. If the shard is
-contended, it falls back to the write lock path. A hit records the key hash into
-the read buffer. After the shard has warmed past the warmup threshold, a hit also
-marks the item as visited. A miss records the hash only after warmup. Expired
-items are removed under the write lock. On the fast path, SieveTinyLFU copies
-the value and marks the item visited before resolving TTL outside the read lock;
-expired entries are revalidated and removed under the write lock before the read
-returns a miss.
+For bounded SieveTinyLFU, `Get` probes the shard table without taking any shard lock. On a miss, it may opportunistically claim `drainMu`, drain pending writes,
+and look again. This handles the common race where a `Get` follows a queued `SetAsync` for the same key, without forcing every async write to become synchronous.
 
-The SieveTinyLFU warmup threshold is `size*2 < cap`. Before that threshold, new
-writes skip admission/frequency work and segment pressure is not enforced; new
-entries are allowed to fill probation.
+On a Sieve hit after warmup:
+
+- `visited` is set with a conditional atomic store
+- the key hash is sampled into the per-shard read buffer
+- stats are recorded only when `StatsEnabled` is true
+
+The value and expiry are copied from immutable item fields. TTL is checked after the table lookup. If the item is expired, the read revalidates it under the
+shard write lock, removes it, and returns a miss. Before warmup, Sieve skips read sampling and visited-bit writes because admission is unconditional and the
+frequency sketch is not used yet.
+
+The SieveTinyLFU warmup threshold is `size*2 < cap`. Before that threshold, new writes skip frequency/admission work and are allowed to fill probation.
 
 ## Eviction Policies
 
@@ -210,47 +233,46 @@ const (
 
 ### LRU
 
-LRU uses the shard's intrusive list with sentinel head and tail nodes. New and
-updated items are inserted at the head. Reads move the item to the head. Eviction
+LRU uses the shard's intrusive list with sentinel head and tail nodes. New and updated items go to the head. Reads move the item back to the head. Eviction
 drops `tail.prev`.
 
 Operations are O(1) under the shard write lock.
 
 ### FIFO
 
-FIFO uses the same intrusive list, but reads do not move nodes. New items are
-added at the head, so `tail.prev` is the oldest inserted item and is evicted.
+FIFO uses the same list, but reads leave nodes in place. New items are added at the head, so `tail.prev` remains the oldest inserted resident and is evicted.
 
 ### LFU
 
-LFU uses an ascending circular list of frequency buckets. Each bucket contains a
-map of items at that exact frequency, and `itemFreq` maps each item back to its
-bucket.
+LFU uses an ascending circular list of frequency buckets. Each bucket contains the items at one exact frequency, and `itemFreq` maps each item back to its bucket.
 
-New items start at frequency 1. Reads move the item to frequency `n+1`,
-creating or removing buckets as needed. Eviction picks one item from the lowest
-frequency bucket. Current LFU eviction does not use recency to break ties.
-
-Updating an existing LFU key resets it to frequency 1.
+New items start at frequency 1. Reads move the item to frequency `n+1`, creating or removing buckets as needed. Eviction picks one item from the lowest
+frequency bucket. Current LFU eviction does not use recency to break ties. Updating an existing LFU key resets it to frequency 1.
 
 ### SieveTinyLFU
 
-SieveTinyLFU is the default bounded policy. It combines:
+SieveTinyLFU is the default bounded policy. It combines a small recency window with frequency admission and SIEVE replacement:
+
+In this document, "adaptive", "self-adapting", and "self-tuning" refer to
+policy-level behavior inside SieveTinyLFU: admission, replacement, and the
+probation/main split. They do not mean whole-system auto-tuning of shard count,
+write allocation strategy, queue sizing, lock choice, GC behavior, or runtime
+environment.
 
 - a probation FIFO queue for new entries
 - a main SIEVE queue for entries with reuse evidence
-- two compact ghost FIFOs of recently evicted fingerprints: `ghost` (B1) for
-  probation victims and `mghost` (B2) for main victims
-- a TinyLFU-style frequency estimator
-- a small adaptive controller for the probation/main split
-- a self-tuning admission controller (recency vs frequency) driven by the B2 ghost
+- a B1 ghost FIFO of recently evicted probation fingerprints
+- a B2 ghost FIFO of recently evicted main fingerprints
+- a doorkeeper plus count-min sketch frequency estimator
+- a policy-level adaptive controller for the probation/main split
+- a policy-level self-tuning admission controller for recency-biased vs frequency-biased tie-breaking
 
-It is allocated only for shards with `cap > 0`.
+The policy state exists only on bounded Sieve shards.
 
 #### Segment Sizing
 
-`ProbationRatio` and `GhostRatio` are percentages. A zero value means "use the
-default", not "zero capacity".
+`ProbationRatio` and `GhostRatio` are percentages. Zero means "use the
+default", not "allocate zero".
 
 For a shard capacity `c`:
 
@@ -259,145 +281,101 @@ For a shard capacity `c`:
 - initial probation cap is clamped from `c * ProbationRatio / 100`
 - main cap is `c - probationCap`
 - B1 ghost cap is `mainCap * GhostRatio / 100`, with a minimum of 1 when main exists
-- B2 ghost cap is `c` (about one shard-capacity of recent main-victim fingerprints)
+- B2 ghost cap is `c`, about one shard-capacity of recent main-victim fingerprints
 - adaptation step is `max(1, c/100)`
-- sketch/doorkeeper sample size is `max(c*10, 1024)`
+- sketch/doorkeeper counter count starts at `max(c*10, 1024)`
 
 #### Frequency Estimator
 
-The frequency path uses a doorkeeper plus a count-min sketch:
+The frequency estimator is a doorkeeper in front of a count-min sketch:
 
 - the doorkeeper is a 2-hash Bloom-style filter
 - the first observation sets doorkeeper bits only
 - later observations add to the sketch
 - `estimate` returns the sketch estimate plus one if the doorkeeper still contains the item
 - the sketch has 4-bit saturating counters packed 16 per `uint64`
-- four indexes are derived by rotating the key hash and applying xxHash64 avalanche
-- all counters are aged by right-shifting after `sampleSize * 10` observations
+- four indexes are derived by rotating the key hash and applying the xxHash64 avalanche finalizer
+- counters are aged by right-shifting after `resetAt` observations
 - aging also clears the doorkeeper
 
-Reads do not update the sketch directly. They write hashes into a striped,
-lossy, per-shard read buffer. The worker drains those samples into the estimator
-before and between write batches.
+Reads do not update the sketch directly. They append key hashes to a striped, lossy, per-shard read buffer. The worker drains those samples into the
+estimator before and between write batches. If a stripe fills faster than the worker can drain it, old samples are overwritten. That can reduce frequency
+accuracy, but it cannot corrupt cache contents.
 
-The read buffer has up to 16 stripes, rounded to a power of two from
-`GOMAXPROCS`. `procID()` uses `runtime.procPin` through `go:linkname`
-as stripe hint. A full stripe overwrites old samples; that can reduce
-frequency accuracy but cannot corrupt cache contents.
+The read buffer has up to 16 stripes, rounded to a power of two from `GOMAXPROCS`. `procID()` uses `runtime.procPin` through `go:linkname` as a stripe hint.
+
+#### Ghost Queues
+
+B1 and B2 store full 64-bit key hashes, not full keys. Each ghost queue is a fixed-size FIFO ring plus an open-addressed index, so membership checks, adds,
+and removes are O(1) while the shard is being maintained. A ghost false positive requires a full 64-bit hash collision.
+
+B1 hits mean a probation victim returned quickly, so the item is readmitted directly into main. B2 hits mean a main victim returned. That is the
+"resurrection" signal used by both adaptive controllers.
 
 #### Admission And Replacement
 
-SieveTinyLFU inserts follow this path:
+SieveTinyLFU inserts work like this:
 
 1. During warmup, insert into probation and skip frequency/admission work.
-2. After warmup, record the key hash in the estimator, and note a B2 resurrection
-   if the key was a recent main-eviction victim.
-3. If `(hash, tag)` is in the B1 ghost queue, remove the ghost entry and insert the
-   item directly into main with `visited=true`.
+2. After warmup, record the key hash in the estimator and note a B2 resurrection if the key was a recent main-eviction victim.
+3. If the hash is in B1, remove the ghost entry and insert the item directly into main with `visited=true`.
 4. Otherwise insert into probation with `reuse=0` and `visited=false`.
 5. Enforce resident capacity and segment pressure.
+6. Publish the item into the table only if it still belongs to a Sieve queue.
 
-Probation eviction examines the probation tail:
+When probation is over pressure, eviction starts at the probation tail:
 
 - if the item has `reuse >= 1` or `visited=true`, it is promoted to main
-- otherwise it is evicted and recorded in the ghost queue
+- otherwise it is evicted and recorded in B1
 
 Main eviction uses a SIEVE hand:
 
 - start from `hand`, falling back to the main tail when needed
 - scan up to `defaultMainVictimScan` items
-- if an item is visited, clear `visited`, decrement `reuse` if positive, and move backward
+- if an item is visited, clear `visited`, decrement `reuse` if positive, count a main survival, and move backward
 - the first unvisited item is the main victim
 - forced eviction can take a candidate after the bounded scan
 
-When a probation promotion or ghost-hit item competes with a main victim,
-`shouldAdmit` compares TinyLFU estimates, and the admission tuner (see Adaptation)
-decides how ties are broken:
+When a probation promotion or B1 ghost-hit item competes with a main victim, `shouldAdmit` compares their TinyLFU estimates. The admission tuner decides how
+ties are handled:
 
-- in the default recency mode, ties favor proven short-term reuse: ghost hits,
-  probation promotions, unvisited victims, and victims with zero reuse
-- in frequency mode it is plain TinyLFU - the candidate is admitted only when its
-  estimate strictly beats the victim's, so the incumbent wins ties
+- recency mode favors candidates with proven short-term reuse, such as B1 ghost hits and probation promotions
+- frequency mode is plain TinyLFU: the candidate is admitted only when its estimate strictly beats the victim's, so the incumbent wins ties
 
-A main eviction victim's `(hash, tag)` is recorded in the B2 ghost. If that key is
-inserted again later, the reinsertion is a "resurrection": evidence the cache
-evicted an item it still needed. Resurrections do not change placement; they are
-the signal the admission tuner reads.
+Capacity enforcement is bounded by `maxEvictionWork`. If that pass spends its
+budget promoting probation entries and still does not restore capacity, a forced
+tail drop brings the shard back under its limit.
 
-Capacity enforcement is bounded by `maxEvictionWork`. If the bounded pass cannot
-restore capacity because it spent work promoting probation entries, a forced tail
-drop restores the shard to capacity.
+#### Policy-Level Adaptation
 
-#### Adaptation
+Adaptation is internal to SieveTinyLFU's policy state; there is no public switch
+for it. It does not tune write-path memory layout, queue sizes, shard count, or
+other runtime/system parameters. `tick` runs once per maintenance window. The window is `capacity * 4`, with a minimum of 8192
+observations for shards whose capacity is at least 1024.
 
-Adaptation is part of SieveTinyLFU and has no public on/off switch. `tick` fires
-once per window of `capacity * 10` observations and drives two independent
-controllers off the same per-cycle counters, all maintained on the
-single-consumer maintenance path (the write worker, or a caller holding the shard
-write lock), so the read path never writes shared policy counters.
+Both controllers run while the shard is being maintained, not on the lock-free read path. Reads only set `visited` and sample hashes.
+They do not increment adaptive counters directly.
 
-**Segment sizing** tracks ghost hits, probation evictions, promotions, and main
-survivals. Main usefulness is measured by `mainSurvivals`: the count of visited
-main residents the SIEVE hand spares during eviction sweeps. It is a
-maintenance-path proxy for "main read hits" that avoids a contended atomic
-increment on every read hit, and it tracks how many distinct main entries reads
-keep alive rather than being skewed by a single hammered key.
+Segment sizing watches B1 ghost hits, probation evictions, promotions, main evictions, B2 resurrections, and main survivals. `mainSurvivals` is the count
+of main residents the SIEVE hand spared because reads set their visited bit. It acts as a low-contention proxy for "main is useful".
 
-The hard case is telling a stationary skew (which wants a tiny probation so main
-pins the hot set) apart from a shifting hot set (which wants a large recency
-window, behaving like LRU): both show heavy probation churn and frequent B1 ghost
-hits, so neither of those signals separates them. The dual-ghost *resurrection
-rate* `cycleB2Hits / cycleMainEvicts` (the same signal the admission tuner reads)
-does. A stationary working set keeps resurrecting its main victims (they are
-still wanted); a shifting one abandons them.
+The hard case is telling a stationary skew from a shifting hot set. Both can produce probation churn and B1 hits. The B2 resurrection rate separates them: a
+looping stationary workload keeps bringing main victims back, while a shifting hot set abandons them. Segment sizing grows probation aggressively when main
+victims are abandoned but probation victims keep returning. It shrinks probation when probation churns more than it promotes and main is earning its capacity.
 
-Segment sizing changes at the periodic controller window:
-
-- a **shifting hot set** grows probation aggressively (a larger step,
-  `probationGrowStepPct` of capacity) when main is churning yet its victims are
-  abandoned (resurrection rate below `probationResurrectLow`) while probation
-  keeps re-evicting entries that return (B1 ghost hits exceed promotions). A
-  `cycleMainEvicts > promotions` gate keeps a stable main - where there are almost
-  no main evictions, so the resurrection rate reads as zero - from being mistaken
-  for a shift, and the grow is suppressed while the admission tuner is pinning a
-  cyclic ("loop") workload with frequency.
-- otherwise `tick` grows probation modestly (one adaptation step) when ghost hits
-  dominate probation evictions (probation too small; this also covers loops), and
-- shrinks probation (one adaptation step) when probation is evicting much more
-  than it promotes and main is earning its keep (more survivals than promotions).
-
-Growing the recency window lets a newly hot key survive to its reuse instead of
-being evicted from a tiny probation before its second access - the case where a
-recency-heavy workload would otherwise trail plain LRU.
-
-**Admission tuning** (`admissionTuner`) self-selects recency vs frequency
-tie-breaking per shard, with no configuration. Recency maximizes hit ratio on
-shifting and bursty working sets but thrashes on stationary cyclic ("loop")
-workloads whose footprint exceeds capacity, where frequency instead pins a stable
-resident set; no fixed mode wins both. The tuner defaults to recency and only
-switches when the B2 ghost shows the loop signature:
-
-- each cycle it computes a *resurrection rate* = B2 ghost hits / main evictions,
-  and the churn cost (evictions + rejects), which tracks the miss rate
-- a loop keeps resurrecting its victims (rate near 1); shifting/bursty workloads
-  abandon theirs (rate near 0), so only a loop accumulates the entry evidence
-- on enough evidence it runs a one-cycle frequency trial, and commits only if the
-  trial actually cuts churn cost below the recency baseline
-- a committed shard reverts to recency the moment churn climbs back (the workload
-  shifted out of its loop), and each reverted trial doubles a cooldown so a
-  workload that never benefits stops re-trialing
-
-Because the entry gate requires the loop signature, recency-biased workloads never
-trial frequency and never regress; the churn-based commit/revert keeps a wrong bet
-to at most about one window. The mode is internal and not configurable.
+Admission tuning chooses recency or frequency tie-breaking per shard. It starts in recency mode. When the B2 resurrection rate shows a loop signature, the
+shard runs one frequency-mode trial and keeps it only if churn cost (`evictions + rejects`) falls. A shard committed to frequency switches back to
+recency when churn climbs again, with exponential backoff after failed trials.
 
 ## Stats
 
-`Stats()` always reports `Size`, `Capacity`, and `Shards`. When
-`StatsEnabled == true`, it also aggregates per-shard hits, misses, evictions,
-expirations, and computes `HitRatio`.
+`Stats()` always reports `Size`, `Cost`, `Capacity`, `MaxCost`, and `Shards`.
+When `StatsEnabled` is true, it also aggregates hits, misses, evictions, and expirations, then computes `HitRatio`.
 
-`PolicyStats()` aggregates SieveTinyLFU counters:
+Stats counters are striped by best-effort P id, capped at 16 stripes, so hot reads do not all hammer the same counter. `StatsEnabled` is false in the root
+`DefaultConfig` because those increments still have runtime cost.
+
+`PolicyStats()` aggregates SieveTinyLFU counters under each shard's read lock:
 
 - `Admits`
 - `Rejects`
@@ -406,36 +384,34 @@ expirations, and computes `HitRatio`.
 - `ProbationEvictions`
 - `MainEvictions`
 
-An admission reject means the newly inserted item lost admission and was removed
-during capacity enforcement.
+An admission reject means a newly inserted candidate lost admission and was removed during capacity enforcement.
 
 ## Manager
 
-`Manager` keeps named configs in a locked map and cache instances in a
-`sync.Map`. `GetCache` creates a cache lazily using the registered config or
-`DefaultConfig`. If concurrent creators race, `LoadOrStore` keeps one cache and
-closes the loser so worker goroutines do not leak.
+`Manager` keeps named configs in a locked map and live cache instances in a `sync.Map`. `GetCache` creates a cache lazily from the registered config, or
+from `DefaultConfig` when nothing was registered. If concurrent creators race, `LoadOrStore` keeps one cache and closes the loser so worker goroutines do not leak.
 
-Named caches are typed. Asking for the same name with a different `K,V` pair
-returns `ErrTypeMismatch`.
+Named caches are typed. Asking for the same name with a different `K, V` pair returns `ErrTypeMismatch`.
 
 ## HTTP Middleware
 
-`httpcache.New` resolves middleware config, constructs a backing
-`kioshun.Cache[string, *Response]`, and installs:
+`httpcache.New` resolves middleware config, creates a backing
+`kioshun.Cache[string, *Response]`, and wires:
 
 - `DefaultKeyGenerator`
 - `DefaultCachePolicy`
 - ignored response headers
 - cacheable method set
 - response body size limit
-- pattern index for invalidation, enabled when `Config.PathExtractor` is set
+- optional pattern index for invalidation
 
-`DefaultConfig` uses SieveTinyLFU, 16 shards, max 100000 responses, 5 minute TTL,
-GET/HEAD, common cacheable status codes, ignored volatile headers, and a 10 MB
-body capture limit.
+The HTTP cache default uses SieveTinyLFU, 16 shards, max 100000 responses, a 5 minute TTL, GET/HEAD, common cacheable status codes, ignored volatile headers,
+and a 10 MB body capture limit. Unlike the root cache default, HTTP middleware enables cache stats unless `DisableStats` is set.
 
-`Wrap` bypasses non-cacheable request methods. For cacheable methods:
+Pattern invalidation is opt-in. Supplying `Config.PathExtractor` enables the path index and attaches a removal listener to the backing cache. The index
+stores keys by URL path and reconciles removals by response identity, so a delayed removal notification will not delete a newer response cached under the same key.
+
+`Wrap` bypasses non-cacheable request methods. For a cacheable request it:
 
 1. Generate the cache key.
 2. Serve a cached response when present.
@@ -443,11 +419,8 @@ body capture limit.
 4. Forward the request to the next handler.
 5. Capture final status, headers, and body.
 6. Ask the policy whether to cache and for what TTL.
-7. When pattern invalidation is enabled and the key maps to a path, add it to the
-   pattern index before the store, so a removal during the store (including a
-   SIEVE admission rejection) is reconciled by the removal listener.
-8. Store a defensive response snapshot in the backing cache, rolling back the
-   index entry if the store fails.
+7. When pattern invalidation is enabled and the key maps to a path, add it to the pattern index before the store, so a removal during the store, including a SieveTinyLFU admission rejection, is reconciled by the removal listener.
+8. Store a defensive response snapshot in the backing cache, rolling back the index entry if the store fails.
 
 The response writer:
 
@@ -457,9 +430,8 @@ The response writer:
 - sets the miss header before committing a miss response
 - captures body bytes up to `MaxBodySize`
 
-`DefaultCachePolicy` rejects non-cacheable methods, non-cacheable statuses,
-oversized bodies, and `Cache-Control: no-cache`, `no-store`, or `private`. It
-uses positive `max-age` first, then positive `Expires`, then `DefaultTTL`.
+`DefaultCachePolicy` rejects non-cacheable methods, non-cacheable statuses, oversized bodies, and `Cache-Control: no-cache`, `no-store`, or `private`.
+It uses a positive `max-age` first, then a positive `Expires`, then `DefaultTTL`.
 
 Key generators include:
 
@@ -470,18 +442,12 @@ Key generators include:
 - `KeyWithUserID`: MD5 of method, full URL, and a user-id header
 - `PathBasedKeyGenerator`: plain `METHOD:/path`
 
-`Invalidate(pattern)` queries the path index for matching keys and deletes them
-from the cache; the removal listener then reconciles the index. Exact patterns
-match keys stored at one path, and patterns ending in `*` match the base path and
-its descendants. Pattern invalidation is enabled by setting `Config.PathExtractor`
-(which also wires the removal listener) together with a compatible key generator,
-such as `KeyWithoutQuery` with `PathExtractorFromKey`; without it the index stays
-empty and `Invalidate` returns 0.
+`Invalidate(pattern)` asks the path index for matching keys and deletes them from the cache. Exact patterns match keys stored at one path. Patterns ending in `*` match the base path and its descendants. Without a configured
+`PathExtractor`, the index stays empty and `Invalidate` returns 0.
 
 ## Algorithm References
 
-The implementation is not a direct copy of any one paper, but the terminology
-and policy design are grounded in these primary references:
+The implementation is not a direct copy of any one paper. The terminology and policy design are grounded in these references:
 
 - [SIEVE: Cache eviction can be simple, effective, and scalable](https://www.usenix.org/system/files/nsdi24-zhang-yazhuo.pdf)
 - [TinyLFU: A Highly Efficient Cache Admission Policy](https://arxiv.org/abs/1512.00727)

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -72,7 +72,7 @@ That design drives the item lifetime rules:
 - `ProbationRatio = 1`
 - `GhostRatio = 100`
 - `CostAdmission = CostAdmissionFrequency`
-- `WriteBufferSize = 1024`
+- `WriteBufferSize = 256`
 - `WriteBatchSize = 64`
 
 `New` validates the config, resolves `DefaultEvictionPolicy` to `SieveTinyLFU` and fills in default write queue settings when they are left as zero.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > <b>v1</b> is a complete redesign, not a drop-in upgrade from earlier releases!
 >
 > The biggest change is that clustering has been removed - the old peer-to-peer features are no longer part of the project. The focus is now on continuously improving cache performance and correctness.
-> The cache core was also rebuilt - `AdmissionLFU` default has been replaced by `SieveTinyLFU` with probation/main queues, ghost entries, TinyLFU sketching, adaptive segment sizing and queued/batched writes.
+> The cache core was also rebuilt - `AdmissionLFU` default has been replaced by a self-adapting `SieveTinyLFU` with probation/main queues, ghost entries, TinyLFU sketching, adaptive segment sizing, lock-free bounded Sieve reads and queued/batched writes.
 >
 > Public APIs changed as part of the redesign, including `New` and `NewDefault` replacing `NewWithDefaults`, cache policy/config names changing and HTTP middleware moving to the `httpcache` package.
 
@@ -30,7 +30,7 @@
 - [Configuration](#configuration)
 - [API](#api)
 - [HTTP Middleware](MIDDLEWARE.md)
-- [Benchmark Results](#benchmark-results)
+- [Benchmarks](#benchmarks)
 
 ## What is Kioshun?
 
@@ -67,10 +67,11 @@ func main() {
     // Set commits the write before returning so the key is immediately readable.
     c.Set("user:456", "John", kioshun.NoExpiration)
 
-    // SetAsync queues the write and returns early.
+    // SetAsync returns early. It may commit inline when the shard is idle
+    // otherwise it queues the write for that shard's worker.
     c.SetAsync("user:789", "Paul", 5*time.Minute)
 
-    // Optional: call Sync() if you want to wait for value back.
+    // Optional: call Sync() when committed visibility is required.
     c.Sync()
 
     // Get value
@@ -94,8 +95,8 @@ config := kioshun.Config{
     DefaultTTL:      30 * time.Minute,     // Default expiration time
     EvictionPolicy:  kioshun.SieveTinyLFU, // Eviction algorithm (default)
     // StatsEnabled records cache activity metrics such as hits, misses and
-    // evictions. Tracking those counters adds runtime cost, so enable it for
-    // tests, diagnostics or deployments where throughput performance is less critical.
+    // evictions. Tracking those counters adds runtime cost so enable it only
+    // if you can accept runtime performance tradeoff.
     StatsEnabled:    true,
     WriteBufferSize: 1024,                 // Per-shard async write queue
     WriteBatchSize:  64,                   // Max commands applied per worker batch
@@ -156,8 +157,9 @@ c.Close() error
 ```
 
 > `Set` is synchronous and gives immediate read-after-write visibility for the key.
-> `SetAsync` is optional and only accepts the write into the shard queue meaning that the value
-> becomes visible after a background worker commits it.
+> `SetAsync` is optional. A nil error means the write was accepted - it may have
+> committed inline already or it may still be queued. Use `Sync` when committed
+> visibility is required.
 
 > Create with `kioshun.New(config, kioshun.WithOnRemove(func(key K, value V, reason kioshun.RemovalReason) { ... }))`
 > to receive a callback for every key removed by capacity eviction,
@@ -214,7 +216,7 @@ http.Handle("/api/users", middleware.Wrap(usersHandler))
 ## Benchmarks
 
 You can find comparison tests in [benchmarks](benchmarks/).
-Those compares Kioshun with Ristretto, BigCache, FreeCache, and go-cache using
+These compare Kioshun with Ristretto, BigCache, FreeCache, and go-cache using
 pre-generated workloads, with async and strict write modes reported separately.
 
 You can rerun the suite on your machine:
@@ -225,18 +227,3 @@ GOCACHE=/tmp/kioshun-go-build go test -run=TestBenchmarkComparisonGetSetup -coun
 GOCACHE=/tmp/kioshun-go-build go test -bench='BenchmarkCacheComparison' -benchmem -run=^$ -benchtime=1s .
 GOCACHE=/tmp/kioshun-go-build go test -bench=. -benchmem -run=^$ -benchtime=1s -timeout=30m .
 ```
-
-Latest checked-in Kioshun snapshot from the comparison suite
-(`2026-06-02`, Apple M4 Max, Go `go1.26.0 darwin/arm64`):
-
-`Measured ops` is the Go benchmark iteration count for that timed workload, not
-the number of unique cache entries.
-
-| Workload | Measured ops | ns/op | B/op | allocs/op |
-| --- | ---: | ---: | ---: | ---: |
-| Set async | 39,253,849 | 40.44 | 0 | 0 |
-| Set strict | 18,755,151 | 67.31 | 0 | 0 |
-| Get TTL | 52,658,330 | 23.53 | 0 | 0 |
-| Get no TTL | 83,651,143 | 15.26 | 0 | 0 |
-| 70% read / 30% write async | 27,072,325 | 44.70 | 0 | 0 |
-| Real-world strict | 22,050,884 | 56.33 | 0 | 0 |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ func main() {
 ```go
 config := kioshun.Config{
     MaxSize:         100000,               // Maximum number of items
+    MaxCost:         0,                    // Optional weighted capacity budget
     ShardCount:      16,                   // Number of shards (0 = auto-detect)
     CleanupInterval: 5 * time.Minute,      // Cleanup frequency
     DefaultTTL:      30 * time.Minute,     // Default expiration time
@@ -109,6 +110,30 @@ if err != nil {
 > Each cache runs one write-worker goroutine per shard (plus a cleanup goroutine when `CleanupInterval > 0`),
 > so `ShardCount` sets the number of background goroutines - default `min(NumCPU*4, 256)`.
 > If you create many caches (e.g. via the cache `Manager`), set `ShardCount` explicitly to bound the total.
+
+### Weighted Capacity
+
+`MaxSize` limits resident entry count. `MaxCost` optionally adds a weighted
+resident budget. Without a custom weigher every entry costs `1`; with
+`WithWeigher`, the cache can enforce byte-like or domain-specific weights.
+
+```go
+config := kioshun.DefaultConfig()
+config.MaxSize = 100000
+config.MaxCost = 256 << 20
+config.CostAdmission = kioshun.CostAdmissionBalanced
+
+c, err := kioshun.New[string, []byte](config, kioshun.WithWeigher(
+    func(_ string, value []byte) int64 {
+        return int64(len(value))
+    },
+))
+```
+
+`CostAdmissionFrequency` preserves TinyLFU frequency admission. For weighted
+SieveTinyLFU caches, `CostAdmissionBalanced` compares frequency divided by
+sqrt(cost), while `CostAdmissionDensity` compares frequency divided by cost.
+Use the balanced mode when request hit ratio and byte pressure both matter.
 
 ## API
 
@@ -148,7 +173,9 @@ type Stats struct {
     Evictions   int64
     Expirations int64
     Size        int64
+    Cost        int64
     Capacity    int64
+    MaxCost     int64
     HitRatio    float64
     Shards      int
 }

--- a/cache.go
+++ b/cache.go
@@ -28,7 +28,9 @@ type Stats struct {
 	Evictions   int64
 	Expirations int64
 	Size        int64
+	Cost        int64
 	Capacity    int64
+	MaxCost     int64
 	HitRatio    float64
 	Shards      int
 }
@@ -45,28 +47,31 @@ type PolicyStats struct {
 
 // Cache is a sharded, lock-based in-memory cache with per-policy metadata.
 type Cache[K comparable, V any] struct {
-	shards      []*shard[K, V] // maps + lists + counters
-	shardMask   uint64         // shards is 2^n; mask = shards-1
-	config      Config
-	perShardCap int64 // floor(MaxSize/shards); 0 => unlimited
-	closeCh     chan struct{}
-	closeOnce   sync.Once
-	closed      int32 // 1 => cache closed
-	workers     sync.WaitGroup
-	itemPool    sync.Pool // *cacheItem[K, V] reuse to lower GC pressure
-	waiterPool  sync.Pool // write ack waiters for sync mutation paths
-	hasher      keyhash.Hasher[K]
-	evictor     evictor[K, V] // nil for SieveTinyLFU; evicts through shard admission state
-	onRemove    func(K, V, RemovalReason)
-	onEvict     func(K, V)
-	removeWake  chan struct{}
+	shards       []*shard[K, V] // maps + lists + counters
+	shardMask    uint64         // shards is 2^n; mask = shards-1
+	config       Config
+	perShardCap  int64 // floor(MaxSize/shards); 0 => unlimited
+	perShardCost int64 // floor(MaxCost/shards); 0 => unlimited
+	closeCh      chan struct{}
+	closeOnce    sync.Once
+	closed       int32 // 1 => cache closed
+	workers      sync.WaitGroup
+	itemPool     sync.Pool // *cacheItem[K, V] reuse to lower GC pressure
+	waiterPool   sync.Pool // write ack waiters for sync mutation paths
+	hasher       keyhash.Hasher[K]
+	weigher      Weigher[K, V]
+	trackCost    bool
+	evictor      evictor[K, V] // nil for SieveTinyLFU; evicts through shard admission state
+	onRemove     func(K, V, RemovalReason)
+	onEvict      func(K, V)
+	removeWake   chan struct{}
 }
 
 type Option[K comparable, V any] func(*Cache[K, V])
 
 // New constructs a Cache from config, returning an error if config is invalid.
 // Shard count is normalized to 2^n (and bounded by MaxSize); background
-// workers start immediately, so callers must Close the cache to release them.
+// workers start immediately so callers must Close the cache to release them.
 func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V], error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
@@ -83,7 +88,6 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 
 	shardCount := config.ShardCount
 	if shardCount <= 0 {
-		// overprovision to reduce lock contention.
 		shardCount = runtime.NumCPU() * shardMultiplier
 		shardCount = min(shardCount, maxShardCount)
 	}
@@ -97,6 +101,14 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		}
 		shardCount = min(shardCount, maxPow2)
 	}
+	if config.MaxCost > 0 {
+		limit := min(config.MaxCost, int64(maxShardCount))
+		maxPow2 := 1
+		for (int64(maxPow2) << 1) <= limit {
+			maxPow2 <<= 1
+		}
+		shardCount = min(shardCount, maxPow2)
+	}
 	shardCount = nextPowerOf2(shardCount)
 
 	cache := &Cache[K, V]{
@@ -104,6 +116,7 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		shardMask: uint64(shardCount - 1),
 		config:    config,
 		closeCh:   make(chan struct{}),
+		trackCost: config.MaxCost > 0 || config.CostAdmission != CostAdmissionFrequency,
 		itemPool: sync.Pool{
 			New: func() any { return &cacheItem[K, V]{} },
 		},
@@ -116,6 +129,9 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 	// remainder below so the aggregate capacity is exactly MaxSize.
 	if config.MaxSize > 0 {
 		cache.perShardCap = config.MaxSize / int64(shardCount)
+	}
+	if config.MaxCost > 0 {
+		cache.perShardCost = config.MaxCost / int64(shardCount)
 	}
 
 	cache.hasher = keyhash.New[K]()
@@ -131,6 +147,13 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 				sc++
 			}
 		}
+		var costCap int64
+		if config.MaxCost > 0 {
+			costCap = cache.perShardCost
+			if int64(i) < config.MaxCost%int64(shardCount) {
+				costCap++
+			}
+		}
 		capHint := 0
 		if sc > 0 {
 			capHint = int(sc)
@@ -139,6 +162,7 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		s := &shard[K, V]{
 			data:       make(map[K]*cacheItem[K, V], capHint),
 			cap:        sc,
+			costCap:    costCap,
 			wake:       make(chan struct{}, 1),
 			writeBatch: make([]writeCommand[K, V], config.WriteBatchSize),
 		}
@@ -148,8 +172,11 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		if config.EvictionPolicy == LFU {
 			s.lfuList = newLFUList[K, V]()
 		}
+		// Config.Validate rejects SieveTinyLFU with a cost budget but no MaxSize so
+		// a bounded Sieve shard always has s.cap > 0 to size its policy from; an
+		// unbounded cache (no MaxSize, no MaxCost) keeps s.sieve nil and never evicts.
 		if config.EvictionPolicy == SieveTinyLFU && s.cap > 0 {
-			s.sieve = newSieveTinyLFU[K, V](s.cap, config.ProbationRatio, config.GhostRatio)
+			s.sieve = newSieveTinyLFU[K, V](s.cap, config.ProbationRatio, config.GhostRatio, config.CostAdmission)
 			s.readBuf = newReadBuffer() // pershard read sampling for the sketch
 		}
 		cache.shards[i] = s
@@ -310,11 +337,29 @@ func (c *Cache[K, V]) Size() int64 {
 	return totalSize
 }
 
+// Cost sums resident item weights across shards (O(shards)).
+func (c *Cache[K, V]) Cost() int64 {
+	if !c.trackCost {
+		return c.Size()
+	}
+	var totalCost int64
+	for _, shard := range c.shards {
+		totalCost += atomic.LoadInt64(&shard.cost)
+	}
+	return totalCost
+}
+
 // Stats aggregates counters and computes hit ratio.
 func (c *Cache[K, V]) Stats() Stats {
 	var stats Stats
 	stats.Size = c.Size()
+	if c.trackCost {
+		stats.Cost = c.Cost()
+	} else {
+		stats.Cost = stats.Size
+	}
 	stats.Capacity = c.config.MaxSize
+	stats.MaxCost = c.config.MaxCost
 	stats.Shards = len(c.shards)
 
 	if c.config.StatsEnabled {
@@ -506,7 +551,7 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 
 	item, exists := shard.data[key]
 	if !exists {
-		warmup := shard.belowSieveWarmupLocked()
+		warmup := shard.belowSieveWarmup()
 		shard.mu.RUnlock()
 		if !warmup {
 			shard.sampleRead(kh, true)
@@ -517,7 +562,7 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 		return getResult[V]{}
 	}
 
-	if shard.sieve != nil && !shard.belowSieveWarmupLocked() {
+	if shard.sieve != nil && !shard.belowSieveWarmup() {
 		shard.sieve.recordReadHit(item)
 	}
 
@@ -569,7 +614,7 @@ func (c *Cache[K, V]) getSieveContended(key K, kh uint64, shard *shard[K, V]) ge
 
 	item, exists := shard.data[key]
 	if !exists {
-		if shard.sieve != nil && !shard.belowSieveWarmupLocked() {
+		if shard.sieve != nil && !shard.belowSieveWarmup() {
 			shard.sampleRead(kh, false)
 		}
 		if c.config.StatsEnabled {
@@ -591,7 +636,7 @@ func (c *Cache[K, V]) getSieveContended(key K, kh uint64, shard *shard[K, V]) ge
 		}
 	}
 
-	if shard.sieve != nil && !shard.belowSieveWarmupLocked() {
+	if shard.sieve != nil && !shard.belowSieveWarmup() {
 		shard.sieve.recordReadHit(item)
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -45,9 +45,10 @@ type PolicyStats struct {
 	MainEvictions      int64
 }
 
-// Cache is a sharded, lock-based in-memory cache with per-policy metadata.
+// Cache is a sharded in-memory cache with per-policy metadata. SieveTinyLFU reads
+// are lock-free; writers (and other policies' reads) are serialized per shard.
 type Cache[K comparable, V any] struct {
-	shards       []*shard[K, V] // maps + lists + counters
+	shards       []*shard[K, V] // tables + lists + counters
 	shardMask    uint64         // shards is 2^n; mask = shards-1
 	config       Config
 	perShardCap  int64 // floor(MaxSize/shards); 0 => unlimited
@@ -56,7 +57,6 @@ type Cache[K comparable, V any] struct {
 	closeOnce    sync.Once
 	closed       int32 // 1 => cache closed
 	workers      sync.WaitGroup
-	itemPool     sync.Pool // *cacheItem[K, V] reuse to lower GC pressure
 	waiterPool   sync.Pool // write ack waiters for sync mutation paths
 	hasher       keyhash.Hasher[K]
 	weigher      Weigher[K, V]
@@ -65,6 +65,8 @@ type Cache[K comparable, V any] struct {
 	onRemove     func(K, V, RemovalReason)
 	onEvict      func(K, V)
 	removeWake   chan struct{}
+
+	stats *stats // per-P striped telemetry; nil unless StatsEnabled
 }
 
 type Option[K comparable, V any] func(*Cache[K, V])
@@ -92,7 +94,6 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		shardCount = min(shardCount, maxShardCount)
 	}
 
-	// guard against zero per-shard capacity when MaxSize is small.
 	if config.MaxSize > 0 {
 		limit := min(config.MaxSize, int64(maxShardCount))
 		maxPow2 := 1
@@ -117,9 +118,6 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		config:    config,
 		closeCh:   make(chan struct{}),
 		trackCost: config.MaxCost > 0 || config.CostAdmission != CostAdmissionFrequency,
-		itemPool: sync.Pool{
-			New: func() any { return &cacheItem[K, V]{} },
-		},
 		waiterPool: sync.Pool{
 			New: func() any { return &writeWaiter{ch: make(chan struct{}, 1)} },
 		},
@@ -135,6 +133,9 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 	}
 
 	cache.hasher = keyhash.New[K]()
+	if config.StatsEnabled {
+		cache.stats = newStats(runtime.GOMAXPROCS(0))
+	}
 	if config.EvictionPolicy != SieveTinyLFU {
 		cache.evictor = createEvictor[K, V](config.EvictionPolicy)
 	}
@@ -160,14 +161,14 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		}
 
 		s := &shard[K, V]{
-			data:       make(map[K]*cacheItem[K, V], capHint),
+			tab:        newHtable[K, V](capHint),
 			cap:        sc,
 			costCap:    costCap,
+			stats:      cache.stats,
 			wake:       make(chan struct{}, 1),
 			writeBatch: make([]writeCommand[K, V], config.WriteBatchSize),
 		}
-		s.queue = newWriteQueue[K, V](config.WriteBufferSize, s.wake, cache.closeCh)
-		s.initLRU()
+		s.queue = newMPSCQueue[K, V](config.WriteBufferSize, s.wake, cache.closeCh)
 
 		if config.EvictionPolicy == LFU {
 			s.lfuList = newLFUList[K, V]()
@@ -176,8 +177,15 @@ func New[K comparable, V any](config Config, opts ...Option[K, V]) (*Cache[K, V]
 		// a bounded Sieve shard always has s.cap > 0 to size its policy from; an
 		// unbounded cache (no MaxSize, no MaxCost) keeps s.sieve nil and never evicts.
 		if config.EvictionPolicy == SieveTinyLFU && s.cap > 0 {
-			s.sieve = newSieveTinyLFU[K, V](s.cap, config.ProbationRatio, config.GhostRatio, config.CostAdmission)
+			// shard index is the queue owner tag; shardCount <= maxShardCount (256)
+			// so it fits a byte and is unique per shard.
+			s.sieve = newSieveTinyLFU[K, V](s.cap, uint8(i), config.ProbationRatio, config.GhostRatio, config.CostAdmission)
 			s.readBuf = newReadBuffer() // pershard read sampling for the sketch
+		}
+		// Only policies backed by the shared LRU list need its sentinels; bounded
+		// SieveTinyLFU keeps residents in its own queues, so it skips them.
+		if s.sieve == nil {
+			s.initLRU()
 		}
 		cache.shards[i] = s
 	}
@@ -269,7 +277,7 @@ func (c *Cache[K, V]) SetWithCallback(key K, value V, ttl time.Duration, callbac
 // Delete removes a key (if present), unlinks it from lists and recycles the node.
 func (c *Cache[K, V]) Delete(key K) bool {
 	kh := c.hasher.Sum(key)
-	deleted, err := c.deleteSync(c.shardByHash(kh), key)
+	deleted, err := c.deleteSync(c.shardByHash(kh), kh, key)
 	if err != nil {
 		return false
 	}
@@ -287,13 +295,14 @@ func (c *Cache[K, V]) Exists(key K) bool {
 		return false
 	}
 
-	shard := c.getShard(key)
+	kh := c.hasher.Sum(key)
+	shard := c.shardByHash(kh)
 	now := time.Now().UnixNano()
 
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
-	item, exists := shard.data[key]
+	item, exists := shard.tab.lookup(kh, key)
 	if !exists {
 		return false
 	}
@@ -301,7 +310,7 @@ func (c *Cache[K, V]) Exists(key K) bool {
 	if item.expireTime > 0 && now > item.expireTime {
 		c.removeItem(shard, item, RemovedExpired)
 		if c.config.StatsEnabled {
-			atomic.AddInt64(&shard.expirations, 1)
+			c.stats.recordExpiration()
 		}
 		return false
 	}
@@ -319,12 +328,12 @@ func (c *Cache[K, V]) Keys() []K {
 
 	for _, shard := range c.shards {
 		shard.mu.RLock()
-		for key, item := range shard.data {
-			if item.expireTime > 0 && now > item.expireTime {
-				continue
+		shard.tab.forEach(func(item *cacheItem[K, V]) bool {
+			if item.expireTime == 0 || now <= item.expireTime {
+				keys = append(keys, item.key)
 			}
-			keys = append(keys, key)
-		}
+			return true
+		})
 		shard.mu.RUnlock()
 	}
 	return keys
@@ -365,13 +374,7 @@ func (c *Cache[K, V]) Stats() Stats {
 	stats.Shards = len(c.shards)
 
 	if c.config.StatsEnabled {
-		for _, shard := range c.shards {
-			stats.Hits += atomic.LoadInt64(&shard.hits)
-			stats.Misses += atomic.LoadInt64(&shard.misses)
-			stats.Evictions += atomic.LoadInt64(&shard.evictions)
-			stats.Expirations += atomic.LoadInt64(&shard.expirations)
-		}
-
+		stats.Hits, stats.Misses, stats.Evictions, stats.Expirations = c.stats.aggregate()
 		total := stats.Hits + stats.Misses
 		if total > 0 {
 			stats.HitRatio = float64(stats.Hits) / float64(total)
@@ -422,7 +425,7 @@ func (c *Cache[K, V]) Cleanup() {
 
 	now := time.Now().UnixNano()
 	for _, shard := range c.shards {
-		shard.cleanup(now, c.config.EvictionPolicy, &c.itemPool, c.config.StatsEnabled)
+		shard.cleanup(now, c.config.EvictionPolicy, c.config.StatsEnabled)
 	}
 }
 
@@ -463,6 +466,10 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 	kh := c.hasher.Sum(key)
 	shard := c.shardByHash(kh)
 
+	// bounded SieveTinyLFU reads are lock-free via getSieve. An unlimited (cap==0)
+	// sieve cache has no policy state (shard.sieve == nil) and never evicts so it
+	// falls through to the lock-based path below with no per-read policy update -
+	// the same as FIFO.
 	if c.config.EvictionPolicy == SieveTinyLFU && shard.sieve != nil {
 		return c.getSieve(key, kh, shard)
 	}
@@ -483,10 +490,10 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 		}
 	}()
 
-	item, exists := shard.data[key]
+	item, exists := shard.tab.lookup(kh, key)
 	if !exists {
 		if c.config.StatsEnabled {
-			atomic.AddInt64(&shard.misses, 1)
+			c.stats.recordMiss()
 		}
 		return getResult[V]{}
 	}
@@ -500,10 +507,10 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 				shard.mu.Lock()
 				shardLockedWrite = true
 
-				item, exists = shard.data[key]
+				item, exists = shard.tab.lookup(kh, key)
 				if !exists {
 					if c.config.StatsEnabled {
-						atomic.AddInt64(&shard.misses, 1)
+						c.stats.recordMiss()
 					}
 					return getResult[V]{now: now}
 				}
@@ -513,8 +520,8 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 
 			c.removeItem(shard, item, RemovedExpired)
 			if c.config.StatsEnabled {
-				atomic.AddInt64(&shard.expirations, 1)
-				atomic.AddInt64(&shard.misses, 1)
+				c.stats.recordExpiration()
+				c.stats.recordMiss()
 			}
 
 			return getResult[V]{now: now}
@@ -526,16 +533,11 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 	case LRU:
 		shard.moveToLRUHead(item)
 	case LFU:
-		item.lastAccess = now
 		shard.lfuList.increment(item)
-	case SieveTinyLFU:
-		// only reached for unlimited (cap==0) SieveTinyLFU shards, which have no
-		// policy state; resident reads go through getSieve otherwise.
-		item.lastAccess = now
 	}
 
 	if c.config.StatsEnabled {
-		atomic.AddInt64(&shard.hits, 1)
+		c.stats.recordHit()
 	}
 
 	return getResult[V]{
@@ -546,29 +548,39 @@ func (c *Cache[K, V]) get(key K) getResult[V] {
 	}
 }
 
+// getSieve is the lock-free SieveTinyLFU read path. It probes the shard table
+// without taking any lock; the only shared state a hit writes is the visited bit
+// (a conditional atomic store). Item value/key/hash/expireTime are immutable
+// after publication, so a reader that races an eviction still reads a consistent
+// snapshot - the evicted item stays alive until the reader (and the GC) are done.
 func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V] {
-	if !shard.mu.TryRLock() {
-		return c.getSieveContended(key, kh, shard)
-	}
+	item, exists := shard.tab.lookup(kh, key)
 
-	item, exists := shard.data[key]
-	if !exists {
-		warmup := shard.belowSieveWarmup()
-		shard.mu.RUnlock()
-		if !warmup {
-			shard.sampleRead(kh, true)
-		}
-		if c.config.StatsEnabled {
-			atomic.AddInt64(&shard.misses, 1)
-		}
-		return getResult[V]{}
-	}
-
-	// During warmup admission is unconditional, so the frequency sketch is never
+	// during warmup admission is unconditional, so the frequency sketch is never
 	// consulted; skip both the visited-bit update and read sampling so a working
 	// set that fits under capacity (and therefore never leaves warmup) pays none
 	// of the sketch-feeding cost on its read hot path.
 	warmup := shard.belowSieveWarmup()
+
+	if !exists {
+		// a read never waits for the writer, so a miss may be a Set still
+		// queued for this shard. Drain pending writes and re-check
+		// before declaring a miss so a Get racing a Set of the same key still sees
+		// it without making writes synchronous.
+		if it, ok := c.drainMissAndLookup(shard, kh, key); ok {
+			item = it
+			warmup = shard.belowSieveWarmup()
+		} else {
+			if !warmup {
+				shard.sampleRead(kh)
+			}
+			if c.config.StatsEnabled {
+				c.stats.recordMiss()
+			}
+			return getResult[V]{}
+		}
+	}
+
 	if shard.sieve != nil && !warmup {
 		shard.sieve.recordReadHit(item)
 	}
@@ -578,24 +590,19 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 		expireTime: item.expireTime,
 		ok:         true,
 	}
-	shard.mu.RUnlock()
 
-	// Resolve expiry only after releasing the read lock. time.Now() is a vDSO
-	// call which means that holding the shared lock across it lengthens every reader's
-	// section, which under load makes TryRLock fail more often and pushes readers
-	// onto the exclusive getSieveContended path. RecordReadHit above only sets the visited
-	// bit, so recording a read on an entry we then find expired is harmless: the
-	// entry is removed (and its bit cleared) below and the adaptive controller is
-	// never touched on the read path.
+	// resolve expiry off the hot path; only an expired hit takes the write lock to
+	// remove the entry. recordReadHit above only set the visited bit, so recording
+	// a read on an entry we then find expired is harmless.
 	if res.expireTime > 0 {
 		res.now = time.Now().UnixNano()
 		if res.now > res.expireTime {
 			shard.mu.Lock()
-			if cur, ok := shard.data[key]; ok && cur.expireTime > 0 && res.now > cur.expireTime {
+			if cur, ok := shard.tab.lookup(kh, key); ok && cur.expireTime > 0 && res.now > cur.expireTime {
 				c.removeItem(shard, cur, RemovedExpired)
 				if c.config.StatsEnabled {
-					atomic.AddInt64(&shard.expirations, 1)
-					atomic.AddInt64(&shard.misses, 1)
+					c.stats.recordExpiration()
+					c.stats.recordMiss()
 				}
 				shard.mu.Unlock()
 				return getResult[V]{now: res.now}
@@ -607,61 +614,14 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 	}
 
 	if c.config.StatsEnabled {
-		atomic.AddInt64(&shard.hits, 1)
+		c.stats.recordHit()
 	}
 	// feed the read into the frequency sketch via the per-shard read buffer so
 	// TinyLFU admission reflects read popularity, not just write traffic.
 	if !warmup {
-		shard.sampleRead(kh, true)
+		shard.sampleRead(kh)
 	}
 	return res
-}
-
-func (c *Cache[K, V]) getSieveContended(key K, kh uint64, shard *shard[K, V]) getResult[V] {
-	shard.mu.Lock()
-	defer shard.mu.Unlock()
-
-	item, exists := shard.data[key]
-	if !exists {
-		if shard.sieve != nil && !shard.belowSieveWarmup() {
-			shard.sampleRead(kh, false)
-		}
-		if c.config.StatsEnabled {
-			atomic.AddInt64(&shard.misses, 1)
-		}
-		return getResult[V]{}
-	}
-
-	now := int64(0)
-	if item.expireTime > 0 {
-		now = time.Now().UnixNano()
-		if now > item.expireTime {
-			c.removeItem(shard, item, RemovedExpired)
-			if c.config.StatsEnabled {
-				atomic.AddInt64(&shard.expirations, 1)
-				atomic.AddInt64(&shard.misses, 1)
-			}
-			return getResult[V]{now: now}
-		}
-	}
-
-	warmup := shard.belowSieveWarmup()
-	if shard.sieve != nil && !warmup {
-		shard.sieve.recordReadHit(item)
-	}
-
-	if c.config.StatsEnabled {
-		atomic.AddInt64(&shard.hits, 1)
-	}
-	if !warmup {
-		shard.sampleRead(kh, false)
-	}
-	return getResult[V]{
-		value:      item.value,
-		expireTime: item.expireTime,
-		now:        now,
-		ok:         true,
-	}
 }
 
 func (c *Cache[K, V]) shardByHash(hash uint64) *shard[K, V] {
@@ -676,5 +636,5 @@ func (c *Cache[K, V]) removeItem(s *shard[K, V], item *cacheItem[K, V], reason R
 	case SieveTinyLFU:
 		mode = dropSieve
 	}
-	s.dropItem(item, &c.itemPool, c.config.StatsEnabled, reason, mode)
+	s.dropItem(item, c.config.StatsEnabled, reason, mode)
 }

--- a/cache.go
+++ b/cache.go
@@ -252,8 +252,10 @@ func (c *Cache[K, V]) Set(key K, value V, ttl time.Duration) error {
 	return c.setAndWait(key, value, ttl, nil)
 }
 
-// SetAsync accepts a queued insert/update command for key with TTL. A nil error
-// means the command was accepted; call Sync for committed visibility.
+// SetAsync accepts an insert/update command for key with TTL. A nil error means
+// the command was accepted. When the owning shard is uncontended the write is
+// applied inline before returning (immediate visibility, no async handoff);
+// otherwise it is queued without blocking and Sync gives committed visibility.
 func (c *Cache[K, V]) SetAsync(key K, value V, ttl time.Duration) error {
 	return c.set(key, value, ttl, nil)
 }
@@ -562,7 +564,12 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 		return getResult[V]{}
 	}
 
-	if shard.sieve != nil && !shard.belowSieveWarmup() {
+	// During warmup admission is unconditional, so the frequency sketch is never
+	// consulted; skip both the visited-bit update and read sampling so a working
+	// set that fits under capacity (and therefore never leaves warmup) pays none
+	// of the sketch-feeding cost on its read hot path.
+	warmup := shard.belowSieveWarmup()
+	if shard.sieve != nil && !warmup {
 		shard.sieve.recordReadHit(item)
 	}
 
@@ -604,7 +611,9 @@ func (c *Cache[K, V]) getSieve(key K, kh uint64, shard *shard[K, V]) getResult[V
 	}
 	// feed the read into the frequency sketch via the per-shard read buffer so
 	// TinyLFU admission reflects read popularity, not just write traffic.
-	shard.sampleRead(kh, true)
+	if !warmup {
+		shard.sampleRead(kh, true)
+	}
 	return res
 }
 
@@ -636,14 +645,17 @@ func (c *Cache[K, V]) getSieveContended(key K, kh uint64, shard *shard[K, V]) ge
 		}
 	}
 
-	if shard.sieve != nil && !shard.belowSieveWarmup() {
+	warmup := shard.belowSieveWarmup()
+	if shard.sieve != nil && !warmup {
 		shard.sieve.recordReadHit(item)
 	}
 
 	if c.config.StatsEnabled {
 		atomic.AddInt64(&shard.hits, 1)
 	}
-	shard.sampleRead(kh, false)
+	if !warmup {
+		shard.sampleRead(kh, false)
+	}
 	return getResult[V]{
 		value:      item.value,
 		expireTime: item.expireTime,

--- a/cache_test.go
+++ b/cache_test.go
@@ -918,6 +918,33 @@ func TestDeleteOrdersAfterPendingSet(t *testing.T) {
 	}
 }
 
+// TestSetAsyncAppliesInlineWhenUncontended verifies the opportunistic inline
+// apply: with no competing activity on the owning shard, SetAsync commits the
+// write before returning, so the key is visible without an explicit Sync.
+func TestSetAsyncAppliesInlineWhenUncontended(t *testing.T) {
+	cache := newTestCache[int, int](t, Config{
+		MaxSize:         1024,
+		ShardCount:      8,
+		CleanupInterval: 0,
+		DefaultTTL:      time.Hour,
+		EvictionPolicy:  LRU,
+		WriteBufferSize: 16,
+		WriteBatchSize:  8,
+	})
+	defer cache.Close()
+
+	for i := 0; i < 32; i++ {
+		if err := cache.SetAsync(i, i*7, time.Hour); err != nil {
+			t.Fatalf("SetAsync(%d): %v", i, err)
+		}
+		// No Sync between the write and the read: an uncontended SetAsync must
+		// have applied inline for the key to be visible here.
+		if v, ok := cache.Get(i); !ok || v != i*7 {
+			t.Fatalf("key %d not visible after uncontended SetAsync; got %d ok=%v", i, v, ok)
+		}
+	}
+}
+
 // Basic benchmarks are in cache_bench_test.go
 
 type User struct {

--- a/cache_test.go
+++ b/cache_test.go
@@ -212,11 +212,11 @@ func TestCacheConcurrency(t *testing.T) {
 	numOperations := 100
 
 	// Concurrent writes
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				key := fmt.Sprintf("key:%d:%d", id, j)
 				cache.Set(key, id*numOperations+j, 1*time.Minute)
 			}
@@ -228,7 +228,7 @@ func TestCacheConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				key := fmt.Sprintf("key:%d:%d", id, j)
 				cache.Get(key)
 			}
@@ -809,7 +809,7 @@ func TestSetAsyncReturnsAfterEnqueueBeforeCommit(t *testing.T) {
 		t.Fatal("set blocked until commit; expected enqueue-only return")
 	}
 
-	if _, ok := shard.data["key"]; ok {
+	if _, ok := shard.tab.lookup(cache.hasher.Sum("key"), "key"); ok {
 		t.Fatal("set committed while shard lock was held")
 	}
 
@@ -854,7 +854,7 @@ func TestSetWaitsForCommit(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 	}
 
-	if _, ok := shard.data["key"]; ok {
+	if _, ok := shard.tab.lookup(cache.hasher.Sum("key"), "key"); ok {
 		t.Fatal("set committed while shard lock was held")
 	}
 
@@ -918,9 +918,6 @@ func TestDeleteOrdersAfterPendingSet(t *testing.T) {
 	}
 }
 
-// TestSetAsyncAppliesInlineWhenUncontended verifies the opportunistic inline
-// apply: with no competing activity on the owning shard, SetAsync commits the
-// write before returning, so the key is visible without an explicit Sync.
 func TestSetAsyncAppliesInlineWhenUncontended(t *testing.T) {
 	cache := newTestCache[int, int](t, Config{
 		MaxSize:         1024,
@@ -933,7 +930,7 @@ func TestSetAsyncAppliesInlineWhenUncontended(t *testing.T) {
 	})
 	defer cache.Close()
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		if err := cache.SetAsync(i, i*7, time.Hour); err != nil {
 			t.Fatalf("SetAsync(%d): %v", i, err)
 		}
@@ -945,8 +942,6 @@ func TestSetAsyncAppliesInlineWhenUncontended(t *testing.T) {
 	}
 }
 
-// Basic benchmarks are in cache_bench_test.go
-
 type User struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -954,7 +949,6 @@ type User struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// Test that verifies the new Set method's in-place update behavior
 func TestSetInPlaceUpdate(t *testing.T) {
 	config := Config{
 		MaxSize:         100,
@@ -979,7 +973,7 @@ func TestSetInPlaceUpdate(t *testing.T) {
 	// Get the item pointer before update (if we could access it)
 	shard := cache.getShard("key1")
 	shard.mu.RLock()
-	originalItem := shard.data["key1"]
+	originalItem, _ := shard.tab.lookup(cache.hasher.Sum("key1"), "key1")
 	shard.mu.RUnlock()
 
 	// Update the same key - should reuse the item
@@ -993,7 +987,7 @@ func TestSetInPlaceUpdate(t *testing.T) {
 
 	// Check that item was reused (same pointer)
 	shard.mu.RLock()
-	updatedItem := shard.data["key1"]
+	updatedItem, _ := shard.tab.lookup(cache.hasher.Sum("key1"), "key1")
 	shard.mu.RUnlock()
 
 	if originalItem != updatedItem {
@@ -1007,7 +1001,6 @@ func TestSetInPlaceUpdate(t *testing.T) {
 	}
 }
 
-// Test LFU frequency reset behavior on Set
 func TestSetLFUFrequencyReset(t *testing.T) {
 	config := Config{
 		MaxSize:         3,
@@ -1027,7 +1020,7 @@ func TestSetLFUFrequencyReset(t *testing.T) {
 	waitForWrites(t, cache)
 
 	// Access "a" multiple times to increase frequency
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		cache.Get("a")
 	}
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -464,6 +464,25 @@ func TestNewValidatesConfig(t *testing.T) {
 			value:  -1,
 			reason: "must be >= 0",
 		},
+		{
+			name: "sieve cost budget without max size",
+			config: Config{
+				EvictionPolicy: SieveTinyLFU,
+				MaxCost:        5,
+			},
+			field:  "MaxSize",
+			value:  int64(0),
+			reason: "must be > 0 for SieveTinyLFU when MaxCost is set",
+		},
+		{
+			name: "default policy cost budget without max size",
+			config: Config{
+				MaxCost: 5, // EvictionPolicy unset resolves to SieveTinyLFU
+			},
+			field:  "MaxSize",
+			value:  int64(0),
+			reason: "must be > 0 for SieveTinyLFU when MaxCost is set",
+		},
 	}
 
 	for _, tt := range tests {
@@ -504,6 +523,61 @@ func TestManagerRegisterValidatesConfig(t *testing.T) {
 	}
 	if configErr.Field != "MaxSize" {
 		t.Fatalf("ConfigError.Field = %q, want MaxSize", configErr.Field)
+	}
+}
+
+func TestRegisterCacheAppliesTypedOptions(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(func() { manager.CloseAll() })
+
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	err := RegisterCache[string, []byte](manager, "weighted", cfg, WithWeigher(func(_ string, value []byte) int64 {
+		return int64(len(value))
+	}))
+	if err != nil {
+		t.Fatalf("RegisterCache() error = %v", err)
+	}
+
+	cache, err := GetCache[string, []byte](manager, "weighted")
+	if err != nil {
+		t.Fatalf("GetCache() error = %v", err)
+	}
+	if err := cache.Set("small", []byte("1234"), NoExpiration); err != nil {
+		t.Fatalf("Set small error = %v", err)
+	}
+	if got := cache.Cost(); got != 4 {
+		t.Fatalf("Cost() = %d, want weighted cost 4", got)
+	}
+	if err := cache.Set("large", make([]byte, 11), NoExpiration); !errors.Is(err, ErrItemTooLarge) {
+		t.Fatalf("Set large error = %v, want ErrItemTooLarge", err)
+	}
+}
+
+func TestRegisterCacheTypeMismatchDoesNotCreateInstance(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(func() { manager.CloseAll() })
+
+	cfg := DefaultConfig()
+	cfg.CleanupInterval = 0
+	if err := RegisterCache[int, int](manager, "typed", cfg); err != nil {
+		t.Fatalf("RegisterCache() error = %v", err)
+	}
+
+	if _, err := GetCache[string, int](manager, "typed"); !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("GetCache() mismatch error = %v, want ErrTypeMismatch", err)
+	}
+	if stats := manager.Stats(); len(stats) != 0 {
+		t.Fatalf("type mismatch created a cache instance; stats=%v", stats)
+	}
+
+	if _, err := GetCache[int, int](manager, "typed"); err != nil {
+		t.Fatalf("GetCache() with registered type error = %v", err)
 	}
 }
 
@@ -573,6 +647,38 @@ func TestManagerCloseAllPreservesConfigs(t *testing.T) {
 	}
 }
 
+func TestManagerCloseAllPreservesTypedRegistration(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(func() { manager.CloseAll() })
+
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 5
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	if err := RegisterCache[string, []byte](manager, "weighted", cfg, WithWeigher(func(_ string, value []byte) int64 {
+		return int64(len(value))
+	})); err != nil {
+		t.Fatalf("RegisterCache() error = %v", err)
+	}
+	if _, err := GetCache[string, []byte](manager, "weighted"); err != nil {
+		t.Fatalf("GetCache() error = %v", err)
+	}
+	if err := manager.CloseAll(); err != nil {
+		t.Fatalf("CloseAll() error = %v", err)
+	}
+
+	cache, err := GetCache[string, []byte](manager, "weighted")
+	if err != nil {
+		t.Fatalf("GetCache() after CloseAll error = %v", err)
+	}
+	if err := cache.Set("large", make([]byte, 6), NoExpiration); !errors.Is(err, ErrItemTooLarge) {
+		t.Fatalf("Set large error = %v, want ErrItemTooLarge after CloseAll rebuild", err)
+	}
+}
+
 func TestGetCacheWithConfig(t *testing.T) {
 	manager := NewManager()
 	t.Cleanup(func() { manager.CloseAll() })
@@ -608,6 +714,34 @@ func TestGetCacheWithConfig(t *testing.T) {
 	// Type mismatch is reported, mirroring GetCache.
 	if _, err := GetCacheWithConfig[string, string](manager, "c", cfg); !errors.Is(err, ErrTypeMismatch) {
 		t.Fatalf("GetCacheWithConfig() type mismatch error = %v, want ErrTypeMismatch", err)
+	}
+}
+
+func TestGetCacheWithConfigAppliesTypedOptions(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(func() { manager.CloseAll() })
+
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 8
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	cache, err := GetCacheWithConfig[string, []byte](manager, "weighted", cfg, WithWeigher(func(_ string, value []byte) int64 {
+		return int64(len(value))
+	}))
+	if err != nil {
+		t.Fatalf("GetCacheWithConfig() error = %v", err)
+	}
+	if err := cache.Set("small", []byte("12345"), NoExpiration); err != nil {
+		t.Fatalf("Set small error = %v", err)
+	}
+	if got := cache.Cost(); got != 5 {
+		t.Fatalf("Cost() = %d, want weighted cost 5", got)
+	}
+	if err := cache.Set("large", make([]byte, 9), NoExpiration); !errors.Is(err, ErrItemTooLarge) {
+		t.Fatalf("Set large error = %v, want ErrItemTooLarge", err)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -31,10 +31,31 @@ const (
 	SieveTinyLFU
 )
 
+// CostAdmission controls how SieveTinyLFU compares an incoming weighted item
+// against a resident victim when MaxCost/WithWeigher are used.
+type CostAdmission int
+
+const (
+	// CostAdmissionFrequency preserves the current TinyLFU comparison:
+	// estimate(candidate) > estimate(victim).
+	CostAdmissionFrequency CostAdmission = iota
+	// CostAdmissionBalanced compares frequency divided by sqrt(cost), a middle
+	// ground between request-hit and byte-hit objectives.
+	CostAdmissionBalanced
+	// CostAdmissionDensity compares frequency divided by cost, favoring dense
+	// hot entries when request hit ratio matters more than byte hit ratio.
+	CostAdmissionDensity
+)
+
 // Config controls cache capacity, sharding, eviction, and the async write
 // pipeline. Use DefaultConfig for recommended settings.
 type Config struct {
-	MaxSize         int64
+	MaxSize int64
+	// MaxCost limits total resident item cost. The budget is distributed across
+	// shards and enforced per shard so the maximum single item cost is bounded by
+	// that item's shard budget, ~ ceil(MaxCost / ShardCount). Zero disables
+	// weighted capacity.
+	MaxCost         int64
 	ShardCount      int
 	CleanupInterval time.Duration
 	DefaultTTL      time.Duration
@@ -45,6 +66,7 @@ type Config struct {
 	StatsEnabled    bool
 	ProbationRatio  uint8
 	GhostRatio      uint8
+	CostAdmission   CostAdmission
 	WriteBufferSize int // bounded per-shard queue depth for async writes.
 	WriteBatchSize  int // caps how many queued writes a shard worker applies under one lock.
 }
@@ -54,6 +76,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		MaxSize:         defaultMaxSize,
+		MaxCost:         0,
 		ShardCount:      0,
 		CleanupInterval: defaultCleanupInterval,
 		DefaultTTL:      defaultTTL,
@@ -61,6 +84,7 @@ func DefaultConfig() Config {
 		StatsEnabled:    false,
 		ProbationRatio:  defaultProbationRatio,
 		GhostRatio:      defaultGhostRatio,
+		CostAdmission:   CostAdmissionFrequency,
 		WriteBufferSize: defaultWriteBufferSize,
 		WriteBatchSize:  defaultWriteBatchSize,
 	}
@@ -70,6 +94,9 @@ func DefaultConfig() Config {
 func (c Config) Validate() error {
 	if c.MaxSize < 0 {
 		return newConfigError("MaxSize", c.MaxSize, "must be >= 0")
+	}
+	if c.MaxCost < 0 {
+		return newConfigError("MaxCost", c.MaxCost, "must be >= 0")
 	}
 	if c.ShardCount < 0 {
 		return newConfigError("ShardCount", c.ShardCount, "must be >= 0")
@@ -82,6 +109,19 @@ func (c Config) Validate() error {
 	}
 	if c.EvictionPolicy < DefaultEvictionPolicy || c.EvictionPolicy > SieveTinyLFU {
 		return newConfigError("EvictionPolicy", c.EvictionPolicy, "must be a known eviction policy")
+	}
+	// SieveTinyLFU sizes its sketch, ghost queue, and probation/main split from an
+	// item count. A cost budget alone (bytes) is a different dimension and would
+	// mis-size those structures, so a weighted Sieve cache must also bound items.
+	policy := c.EvictionPolicy
+	if policy == DefaultEvictionPolicy {
+		policy = DefaultConfig().EvictionPolicy
+	}
+	if policy == SieveTinyLFU && c.MaxSize <= 0 && c.MaxCost > 0 {
+		return newConfigError("MaxSize", c.MaxSize, "must be > 0 for SieveTinyLFU when MaxCost is set")
+	}
+	if c.CostAdmission < CostAdmissionFrequency || c.CostAdmission > CostAdmissionDensity {
+		return newConfigError("CostAdmission", c.CostAdmission, "must be a known cost admission mode")
 	}
 	if c.ProbationRatio > 100 {
 		return newConfigError("ProbationRatio", c.ProbationRatio, "must be <= 100")

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ const (
 	defaultMaxSize         = 10000
 	defaultCleanupInterval = 5 * time.Minute
 	defaultTTL             = 30 * time.Minute
-	defaultWriteBufferSize = 1024
+	defaultWriteBufferSize = 256
 	defaultWriteBatchSize  = 64
 
 	// scale by CPUs and round to 2^n
@@ -36,13 +36,12 @@ const (
 type CostAdmission int
 
 const (
-	// CostAdmissionFrequency preserves the current TinyLFU comparison:
 	// estimate(candidate) > estimate(victim).
 	CostAdmissionFrequency CostAdmission = iota
-	// CostAdmissionBalanced compares frequency divided by sqrt(cost), a middle
+	// compares frequency divided by sqrt(cost), a middle
 	// ground between request-hit and byte-hit objectives.
 	CostAdmissionBalanced
-	// CostAdmissionDensity compares frequency divided by cost, favoring dense
+	// acompares frequency divided by cost, favoring dense
 	// hot entries when request hit ratio matters more than byte hit ratio.
 	CostAdmissionDensity
 )
@@ -50,25 +49,18 @@ const (
 // Config controls cache capacity, sharding, eviction, and the async write
 // pipeline. Use DefaultConfig for recommended settings.
 type Config struct {
-	MaxSize int64
-	// MaxCost limits total resident item cost. The budget is distributed across
-	// shards and enforced per shard so the maximum single item cost is bounded by
-	// that item's shard budget, ~ ceil(MaxCost / ShardCount). Zero disables
-	// weighted capacity.
+	MaxSize         int64
 	MaxCost         int64
 	ShardCount      int
 	CleanupInterval time.Duration
 	DefaultTTL      time.Duration
 	EvictionPolicy  EvictionPolicy
-	// StatsEnabled records cache activity metrics such as hits, misses and
-	// evictions. Tracking those counters adds runtime cost so enable it for
-	// tests, diagnostics or deployments where throughput perf.is less critical.
 	StatsEnabled    bool
 	ProbationRatio  uint8
 	GhostRatio      uint8
 	CostAdmission   CostAdmission
-	WriteBufferSize int // bounded per-shard queue depth for async writes.
-	WriteBatchSize  int // caps how many queued writes a shard worker applies under one lock.
+	WriteBufferSize int
+	WriteBatchSize  int
 }
 
 // DefaultConfig returns self-tuning SieveTinyLFU with stats disabled and shard
@@ -92,6 +84,7 @@ func DefaultConfig() Config {
 
 // Validate reports invalid cache configuration values.
 func (c Config) Validate() error {
+	// --- Capacity and lifecycle ---
 	if c.MaxSize < 0 {
 		return newConfigError("MaxSize", c.MaxSize, "must be >= 0")
 	}
@@ -107,28 +100,33 @@ func (c Config) Validate() error {
 	if c.DefaultTTL < 0 && c.DefaultTTL != NoExpiration {
 		return newConfigError("DefaultTTL", c.DefaultTTL, "must be >= 0 or NoExpiration")
 	}
+
+	// --- Eviction policy ---
 	if c.EvictionPolicy < DefaultEvictionPolicy || c.EvictionPolicy > SieveTinyLFU {
 		return newConfigError("EvictionPolicy", c.EvictionPolicy, "must be a known eviction policy")
 	}
-	// SieveTinyLFU sizes its sketch, ghost queue, and probation/main split from an
-	// item count. A cost budget alone (bytes) is a different dimension and would
-	// mis-size those structures, so a weighted Sieve cache must also bound items.
 	policy := c.EvictionPolicy
 	if policy == DefaultEvictionPolicy {
 		policy = DefaultConfig().EvictionPolicy
 	}
+	// SieveTinyLFU sizes its sketch/ghost/probation split from an item count, so a
+	// cost-only budget would mis-size them: a weighted Sieve cache must bound items too.
 	if policy == SieveTinyLFU && c.MaxSize <= 0 && c.MaxCost > 0 {
 		return newConfigError("MaxSize", c.MaxSize, "must be > 0 for SieveTinyLFU when MaxCost is set")
 	}
 	if c.CostAdmission < CostAdmissionFrequency || c.CostAdmission > CostAdmissionDensity {
 		return newConfigError("CostAdmission", c.CostAdmission, "must be a known cost admission mode")
 	}
+
+	// --- SieveTinyLFU tuning ratios (% of capacity) ---
 	if c.ProbationRatio > 100 {
 		return newConfigError("ProbationRatio", c.ProbationRatio, "must be <= 100")
 	}
 	if c.GhostRatio > 100 {
 		return newConfigError("GhostRatio", c.GhostRatio, "must be <= 100")
 	}
+
+	// ---Async write pipeline ---
 	if c.WriteBufferSize < 0 {
 		return newConfigError("WriteBufferSize", c.WriteBufferSize, "must be >= 0")
 	}

--- a/cost.go
+++ b/cost.go
@@ -1,0 +1,16 @@
+package kioshun
+
+// Weigher reports the relative capacity cost for a cache entry. The default
+// cost is 1, preserving entry count when MaxCost is unset.
+type Weigher[K comparable, V any] func(K, V) int64
+
+// WithWeigher configures typed item weights for MaxCost enforcement and
+// cost-aware SieveTinyLFU admission. A nil weigher is ignored.
+func WithWeigher[K comparable, V any](weigher Weigher[K, V]) Option[K, V] {
+	return func(c *Cache[K, V]) {
+		if weigher != nil {
+			c.weigher = weigher
+			c.trackCost = true
+		}
+	}
+}

--- a/cost_test.go
+++ b/cost_test.go
@@ -1,0 +1,247 @@
+package kioshun
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWeightedLRUTracksCostAndEvictsToMaxCost(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	cache, err := New[int, int](cfg, WithWeigher(func(_ int, value int) int64 {
+		return int64(value)
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer cache.Close()
+
+	for _, key := range []int{1, 2, 3} {
+		if err := cache.Set(key, 4, time.Hour); err != nil {
+			t.Fatalf("Set(%d) error = %v", key, err)
+		}
+	}
+
+	if cost := cache.Cost(); cost > cfg.MaxCost {
+		t.Fatalf("cost=%d exceeds max cost=%d", cost, cfg.MaxCost)
+	}
+	if _, ok := cache.Get(1); ok {
+		t.Fatal("oldest key survived weighted LRU eviction")
+	}
+	if stats := cache.Stats(); stats.Cost != cache.Cost() || stats.MaxCost != cfg.MaxCost {
+		t.Fatalf("stats cost/max=%d/%d want %d/%d", stats.Cost, stats.MaxCost, cache.Cost(), cfg.MaxCost)
+	}
+}
+
+func TestDefaultCacheDoesNotTrackCostMetadata(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+
+	cache, err := New[int, int](cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer cache.Close()
+
+	for key := 0; key < 4; key++ {
+		if err := cache.Set(key, key, time.Hour); err != nil {
+			t.Fatalf("Set(%d) error = %v", key, err)
+		}
+	}
+
+	if cache.trackCost {
+		t.Fatal("default cache enabled cost tracking")
+	}
+	if got := cache.Cost(); got != cache.Size() {
+		t.Fatalf("Cost()=%d, want Size()=%d when MaxCost and WithWeigher are unset", got, cache.Size())
+	}
+	for _, shard := range cache.shards {
+		shard.mu.RLock()
+		for key, item := range shard.data {
+			if item.cost != 0 {
+				shard.mu.RUnlock()
+				t.Fatalf("key %d carries cost metadata cost=%d in default cache", key, item.cost)
+			}
+		}
+		shard.mu.RUnlock()
+	}
+}
+
+func TestWeightedSetRejectsInvalidAndTooLargeCosts(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 10
+	cfg.MaxCost = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+
+	tooLarge, err := New[int, int](cfg, WithWeigher(func(_ int, value int) int64 {
+		return int64(value)
+	}))
+	if err != nil {
+		t.Fatalf("New() tooLarge error = %v", err)
+	}
+	defer tooLarge.Close()
+	if err := tooLarge.Set(1, 11, time.Hour); !errors.Is(err, ErrItemTooLarge) {
+		t.Fatalf("Set too large error=%v, want ErrItemTooLarge", err)
+	}
+
+	negative, err := New[int, int](cfg, WithWeigher(func(int, int) int64 {
+		return -1
+	}))
+	if err != nil {
+		t.Fatalf("New() negative error = %v", err)
+	}
+	defer negative.Close()
+	if err := negative.Set(1, 1, time.Hour); !errors.Is(err, ErrInvalidCost) {
+		t.Fatalf("Set negative cost error=%v, want ErrInvalidCost", err)
+	}
+}
+
+func TestUnboundedSieveAllowsNoEviction(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 0
+	cfg.MaxCost = 0
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = SieveTinyLFU
+
+	cache, err := New[int, int](cfg)
+	if err != nil {
+		t.Fatalf("New() unbounded Sieve error = %v", err)
+	}
+	defer cache.Close()
+
+	// No capacity bound means nothing to size or evict, so the policy state is
+	// never allocated and the cache grows without dropping entries.
+	if cache.shards[0].sieve != nil {
+		t.Fatal("unbounded Sieve shard allocated policy state")
+	}
+	for key := 0; key < 50; key++ {
+		if err := cache.Set(key, key, time.Hour); err != nil {
+			t.Fatalf("Set(%d) error = %v", key, err)
+		}
+	}
+	if got := cache.Size(); got != 50 {
+		t.Fatalf("unbounded cache size=%d, want 50 (no eviction)", got)
+	}
+}
+
+func TestCostOnlyLRUEnforcesBudget(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 0
+	cfg.MaxCost = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	// Non-Sieve policies size from a tail-eviction list, not a frequency sketch,
+	// so a cost-only budget without MaxSize is valid for them.
+	cache, err := New[int, int](cfg, WithWeigher(func(_ int, value int) int64 {
+		return int64(value)
+	}))
+	if err != nil {
+		t.Fatalf("New() cost-only LRU error = %v", err)
+	}
+	defer cache.Close()
+
+	for _, key := range []int{1, 2, 3} {
+		if err := cache.Set(key, 4, time.Hour); err != nil {
+			t.Fatalf("Set(%d) error = %v", key, err)
+		}
+	}
+	if cost := cache.Cost(); cost > cfg.MaxCost {
+		t.Fatalf("cost-only LRU cost=%d exceeds max cost=%d", cost, cfg.MaxCost)
+	}
+}
+
+func TestWeightedMaxCostNormalizesShardCount(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 3
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = LRU
+
+	cache, err := New[int, int](cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer cache.Close()
+
+	if len(cache.shards) > int(cfg.MaxCost) {
+		t.Fatalf("shards=%d exceeds MaxCost=%d and would create zero-budget shards", len(cache.shards), cfg.MaxCost)
+	}
+	for i, shard := range cache.shards {
+		if shard.costCap <= 0 {
+			t.Fatalf("shard %d costCap=%d, want positive cost budget", i, shard.costCap)
+		}
+	}
+}
+
+func TestWeightedSieveEnforcesCostDuringWarmup(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSize = 100
+	cfg.MaxCost = 10
+	cfg.ShardCount = 1
+	cfg.CleanupInterval = 0
+	cfg.EvictionPolicy = SieveTinyLFU
+
+	cache, err := New[int, int](cfg, WithWeigher(func(_ int, value int) int64 {
+		return int64(value)
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer cache.Close()
+
+	for _, key := range []int{1, 2, 3} {
+		if err := cache.Set(key, 4, time.Hour); err != nil {
+			t.Fatalf("Set(%d) error = %v", key, err)
+		}
+	}
+	if cost := cache.Cost(); cost > cfg.MaxCost {
+		t.Fatalf("Sieve cost=%d exceeds max cost=%d", cost, cfg.MaxCost)
+	}
+}
+
+func TestSieveCostAdmissionScores(t *testing.T) {
+	// Cost-aware modes read the denominator from item.cost; the smaller, denser
+	// candidate (cost 1) should beat the larger victim (cost 64) once cost weights
+	// the frequencies, while frequency-only admission keeps the hotter victim.
+	in := &cacheItem[int, int]{key: 1, hash: 1, cost: 1}
+	victim := &cacheItem[int, int]{key: 2, hash: 2, cost: 64}
+
+	frequency := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionFrequency)
+	incrementSieveFrequency(frequency, in.hash, 2)
+	incrementSieveFrequency(frequency, victim.hash, 3)
+	if frequency.shouldAdmit(in, victim, false) {
+		t.Fatal("frequency-only admission should keep the higher-frequency victim")
+	}
+
+	density := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionDensity)
+	incrementSieveFrequency(density, in.hash, 2)
+	incrementSieveFrequency(density, victim.hash, 3)
+	if !density.shouldAdmit(in, victim, false) {
+		t.Fatal("density admission should admit the smaller dense candidate")
+	}
+
+	balanced := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionBalanced)
+	incrementSieveFrequency(balanced, in.hash, 2)
+	incrementSieveFrequency(balanced, victim.hash, 3)
+	if !balanced.shouldAdmit(in, victim, false) {
+		t.Fatal("balanced admission should admit the smaller candidate in this score range")
+	}
+}
+
+func incrementSieveFrequency[K comparable, V any](p *sieveTinyLFU[K, V], h uint64, n int) {
+	for i := 0; i < n; i++ {
+		p.incrementFrequency(h)
+	}
+}

--- a/cost_test.go
+++ b/cost_test.go
@@ -51,7 +51,7 @@ func TestDefaultCacheDoesNotTrackCostMetadata(t *testing.T) {
 	}
 	defer cache.Close()
 
-	for key := 0; key < 4; key++ {
+	for key := range 4 {
 		if err := cache.Set(key, key, time.Hour); err != nil {
 			t.Fatalf("Set(%d) error = %v", key, err)
 		}
@@ -65,13 +65,19 @@ func TestDefaultCacheDoesNotTrackCostMetadata(t *testing.T) {
 	}
 	for _, shard := range cache.shards {
 		shard.mu.RLock()
-		for key, item := range shard.data {
+		var badKey, badCost int64
+		bad := false
+		shard.tab.forEach(func(item *cacheItem[int, int]) bool {
 			if item.cost != 0 {
-				shard.mu.RUnlock()
-				t.Fatalf("key %d carries cost metadata cost=%d in default cache", key, item.cost)
+				badKey, badCost, bad = int64(item.key), item.cost, true
+				return false
 			}
-		}
+			return true
+		})
 		shard.mu.RUnlock()
+		if bad {
+			t.Fatalf("key %d carries cost metadata cost=%d in default cache", badKey, badCost)
+		}
 	}
 }
 
@@ -124,7 +130,7 @@ func TestUnboundedSieveAllowsNoEviction(t *testing.T) {
 	if cache.shards[0].sieve != nil {
 		t.Fatal("unbounded Sieve shard allocated policy state")
 	}
-	for key := 0; key < 50; key++ {
+	for key := range 50 {
 		if err := cache.Set(key, key, time.Hour); err != nil {
 			t.Fatalf("Set(%d) error = %v", key, err)
 		}
@@ -218,21 +224,21 @@ func TestSieveCostAdmissionScores(t *testing.T) {
 	in := &cacheItem[int, int]{key: 1, hash: 1, cost: 1}
 	victim := &cacheItem[int, int]{key: 2, hash: 2, cost: 64}
 
-	frequency := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionFrequency)
+	frequency := newSieveTinyLFU[int, int](8, 0, 25, 100, CostAdmissionFrequency)
 	incrementSieveFrequency(frequency, in.hash, 2)
 	incrementSieveFrequency(frequency, victim.hash, 3)
 	if frequency.shouldAdmit(in, victim, false) {
 		t.Fatal("frequency-only admission should keep the higher-frequency victim")
 	}
 
-	density := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionDensity)
+	density := newSieveTinyLFU[int, int](8, 0, 25, 100, CostAdmissionDensity)
 	incrementSieveFrequency(density, in.hash, 2)
 	incrementSieveFrequency(density, victim.hash, 3)
 	if !density.shouldAdmit(in, victim, false) {
 		t.Fatal("density admission should admit the smaller dense candidate")
 	}
 
-	balanced := newSieveTinyLFU[int, int](8, 25, 100, CostAdmissionBalanced)
+	balanced := newSieveTinyLFU[int, int](8, 0, 25, 100, CostAdmissionBalanced)
 	incrementSieveFrequency(balanced, in.hash, 2)
 	incrementSieveFrequency(balanced, victim.hash, 3)
 	if !balanced.shouldAdmit(in, victim, false) {
@@ -241,7 +247,7 @@ func TestSieveCostAdmissionScores(t *testing.T) {
 }
 
 func incrementSieveFrequency[K comparable, V any](p *sieveTinyLFU[K, V], h uint64, n int) {
-	for i := 0; i < n; i++ {
+	for range n {
 		p.incrementFrequency(h)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,10 @@ var (
 	ErrInvalidConfig = errors.New("invalid cache configuration")
 	// ErrCacheClosed is returned by operations on a closed cache.
 	ErrCacheClosed = errors.New("cache is closed")
+	// ErrInvalidCost is returned when a configured weigher reports a negative cost.
+	ErrInvalidCost = errors.New("cache item cost is invalid")
+	// ErrItemTooLarge is returned when a weighted item cannot fit in its shard cost budget.
+	ErrItemTooLarge = errors.New("cache item cost exceeds shard budget")
 )
 
 // CacheError describes a failure from a named cache operation (register, get, close).

--- a/evict.go
+++ b/evict.go
@@ -4,16 +4,9 @@ package kioshun
 type RemovalReason uint8
 
 const (
-	// RemovedCapacity: an established resident was displaced to keep the shard
-	// within capacity. Only this reason is counted in Stats().Evictions.
 	RemovedCapacity RemovalReason = iota
-	// RemovedRejected: SieveTinyLFU declined to keep an admitted candidate, such
-	// as a just Set key or a promoted probation entry.
 	RemovedRejected
-	// RemovedExpired: the entry passed its TTL and was reclaimed, either by the
-	// background sweeper or lazily on access. Counted in Stats().Expirations.
 	RemovedExpired
-	// RemovedDeleted: the entry was removed by an explicit Delete.
 	RemovedDeleted
 )
 
@@ -107,9 +100,6 @@ func (c *Cache[K, V]) removeNotifyWorker() {
 		case <-c.removeWake:
 			c.drainRemovals()
 		case <-c.closeCh:
-			// deliver whatever was staged before shutdown, then exit. Close waits
-			// on this worker before clearing shards, so no removal can be staged
-			// after this final drain returns.
 			c.drainRemovals()
 			return
 		}

--- a/evict_test.go
+++ b/evict_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 )
 
-// evictRecorder is a concurrency-safe sink for OnRemove notifications.
 type evictRecorder struct {
 	mu      sync.Mutex
 	seen    map[int]string
@@ -87,8 +86,6 @@ func (r *capacityEvictRecorder) value(k int) (string, bool) {
 	return v, ok
 }
 
-// waitFor polls cond until it holds or the deadline passes; removal
-// notifications are delivered asynchronously, so tests cannot assert immediately.
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -188,8 +185,6 @@ func TestOnRemoveAndOnEvict_BothFireForCapacity(t *testing.T) {
 	}
 }
 
-// Every distinct key inserted must end up either resident or reported exactly
-// once to OnRemove; the two sets never overlap and never lose a key.
 func TestOnRemove_CapacityEvictionAccounting(t *testing.T) {
 	for _, policy := range []EvictionPolicy{LRU, LFU, FIFO, SieveTinyLFU} {
 		t.Run(policyName(policy), func(t *testing.T) {
@@ -336,8 +331,6 @@ func TestOnRemove_ExpirationOnAccess(t *testing.T) {
 	}
 }
 
-// Replacing an existing key's value keeps the key resident, so it must not
-// produce an eviction notification.
 func TestOnRemove_NotFiredOnOverwrite(t *testing.T) {
 	rec := newEvictRecorder()
 	c, err := New(
@@ -364,7 +357,6 @@ func TestOnRemove_NotFiredOnOverwrite(t *testing.T) {
 	}
 }
 
-// Clear drops every entry in bulk and must not deliver per-key notifications.
 func TestOnRemove_NotFiredOnClear(t *testing.T) {
 	rec := newEvictRecorder()
 	c, err := New(

--- a/evictor.go
+++ b/evictor.go
@@ -1,48 +1,44 @@
 package kioshun
 
-import (
-	"sync"
-)
-
 // evictor removes one resident item from a bounded shard.
 // Callers hold the shard lock; only choose the victim and leave
-// map removal, policy unlinking, pooling and statistics to shard.dropItem.
+// table removal, policy unlinking and statistics to shard.dropItem.
 type evictor[K comparable, V any] interface {
-	evict(s *shard[K, V], itemPool *sync.Pool, statsEnabled bool)
+	evict(s *shard[K, V], statsEnabled bool)
 }
 
 type lruEvictor[K comparable, V any] struct{}
 
-func (e lruEvictor[K, V]) evict(s *shard[K, V], itemPool *sync.Pool, statsEnabled bool) {
+func (e lruEvictor[K, V]) evict(s *shard[K, V], statsEnabled bool) {
 	if s.tail.prev == s.head {
 		return
 	}
 
-	s.dropItem(s.tail.prev, itemPool, statsEnabled, RemovedCapacity, dropLRU)
+	s.dropItem(s.tail.prev, statsEnabled, RemovedCapacity, dropLRU)
 }
 
 type lfuEvictor[K comparable, V any] struct{}
 
-func (e lfuEvictor[K, V]) evict(s *shard[K, V], itemPool *sync.Pool, statsEnabled bool) {
+func (e lfuEvictor[K, V]) evict(s *shard[K, V], statsEnabled bool) {
 	lfu := s.lfuList.removeLFU()
 	if lfu == nil {
 		return
 	}
 	// removeLFU already unlinked the LFU bucket; dropLRU unlinks the shared LRU
-	// list and map without a redundant lookup.
-	s.dropItem(lfu, itemPool, statsEnabled, RemovedCapacity, dropLRU)
+	// list and table without a redundant lookup.
+	s.dropItem(lfu, statsEnabled, RemovedCapacity, dropLRU)
 }
 
 type fifoEvictor[K comparable, V any] struct{}
 
 // evict removes the tail entry from the shared LRU list. FIFO reads never move
 // entries, so tail.prev remains the oldest inserted resident for this policy.
-func (e fifoEvictor[K, V]) evict(s *shard[K, V], itemPool *sync.Pool, statsEnabled bool) {
+func (e fifoEvictor[K, V]) evict(s *shard[K, V], statsEnabled bool) {
 	if s.tail.prev == s.head {
 		return
 	}
 
-	s.dropItem(s.tail.prev, itemPool, statsEnabled, RemovedCapacity, dropLRU)
+	s.dropItem(s.tail.prev, statsEnabled, RemovedCapacity, dropLRU)
 }
 
 // createEvictor returns the non-Sieve replacement policy for a shard.

--- a/evictor_test.go
+++ b/evictor_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-// TestAllEvictionPolicies verifies that all eviction policies work correctly
 func TestAllEvictionPolicies(t *testing.T) {
 	policies := []EvictionPolicy{LRU, LFU, FIFO, SieveTinyLFU}
 	policyNames := []string{"LRU", "LFU", "FIFO", "SieveTinyLFU"}
@@ -26,7 +25,7 @@ func TestAllEvictionPolicies(t *testing.T) {
 			defer cache.Close()
 
 			// Fill cache beyond capacity to trigger eviction
-			for j := 0; j < 10; j++ {
+			for j := range 10 {
 				cache.Set(string(rune('a'+j)), j, time.Hour)
 			}
 			waitForWrites(t, cache)
@@ -70,7 +69,6 @@ func TestAllEvictionPolicies(t *testing.T) {
 	}
 }
 
-// TestLFUSpecificBehavior tests LFU frequency tracking
 func TestLFUSpecificBehavior(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -115,7 +113,6 @@ func TestLFUSpecificBehavior(t *testing.T) {
 	}
 }
 
-// TestLRUSpecificBehavior tests LRU access order tracking
 func TestLRUSpecificBehavior(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -152,7 +149,6 @@ func TestLRUSpecificBehavior(t *testing.T) {
 	}
 }
 
-// TestSieveTinyLFUSpecificBehavior tests SieveTinyLFU with new adaptive admission filter
 func TestSieveTinyLFUSpecificBehavior(t *testing.T) {
 	config := Config{
 		MaxSize:        6,
@@ -175,12 +171,12 @@ func TestSieveTinyLFUSpecificBehavior(t *testing.T) {
 
 	// Build TinyLFU frequency through repeated access.
 	// High frequency: "a" should get strong SieveTinyLFU admission priority.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		cache.Get("a")
 	}
 
 	// Medium frequency: "b"
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cache.Get("b")
 	}
 
@@ -193,7 +189,7 @@ func TestSieveTinyLFUSpecificBehavior(t *testing.T) {
 	// Try to add a new high-frequency item.
 	cache.Set("high_freq", 100, time.Hour)
 	waitForWrites(t, cache)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cache.Get("high_freq") // Build TinyLFU frequency.
 	}
 
@@ -206,7 +202,6 @@ func TestSieveTinyLFUSpecificBehavior(t *testing.T) {
 		t.Log("No evictions occurred - admission control may be preventing cache pollution")
 	}
 
-	// Verify cache size constraint
 	if statsAfter.Size > 6 {
 		t.Errorf("Cache size %d exceeds max capacity 6", statsAfter.Size)
 	}
@@ -217,7 +212,6 @@ func TestSieveTinyLFUSpecificBehavior(t *testing.T) {
 	}
 }
 
-// TestSieveTinyLFUAdmissionControl tests that SieveTinyLFU uses new adaptive admission control
 func TestSieveTinyLFUAdmissionControl(t *testing.T) {
 	config := Config{
 		MaxSize:        4,
@@ -238,12 +232,12 @@ func TestSieveTinyLFUAdmissionControl(t *testing.T) {
 
 	// Build frequency profiles:
 	// High frequency: "a" (should get guaranteed admission ≥ threshold=3)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		cache.Get("a")
 	}
 
 	// Medium frequency: "b"
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		cache.Get("b")
 	}
 
@@ -258,7 +252,7 @@ func TestSieveTinyLFUAdmissionControl(t *testing.T) {
 	rejected := 0
 
 	// Try adding multiple items - admission control should moderate cache pollution
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		key := fmt.Sprintf("candidate%d", i)
 		cache.Set(key, 100+i, time.Hour)
 		waitForWrites(t, cache)
@@ -302,7 +296,6 @@ func TestSieveTinyLFUAdmissionControl(t *testing.T) {
 	t.Logf("Admitted %d, Rejected %d out of 12 items with SieveTinyLFU admission control", admitted, rejected)
 }
 
-// TestSieveTinyLFUSampleSize tests SieveTinyLFU with different scenarios
 func TestSieveTinyLFUSampleSize(t *testing.T) {
 	config := Config{
 		MaxSize:        10,
@@ -314,8 +307,7 @@ func TestSieveTinyLFUSampleSize(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache to capacity
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		cache.Set(string(rune('a'+i)), i, time.Hour)
 	}
 	waitForWrites(t, cache)
@@ -332,7 +324,7 @@ func TestSieveTinyLFUSampleSize(t *testing.T) {
 
 	// Trigger evictions by adding new items - try many to overcome admission control
 	admittedItems := 0
-	for i := 0; i < 20; i++ { // Try more items to overcome admission control
+	for i := range 20 { // Try more items to overcome admission control
 		evictionsBefore := cache.Stats().Evictions
 		cache.Set(string(rune('x'+i)), 100+i, time.Hour)
 		waitForWrites(t, cache)
@@ -354,7 +346,7 @@ func TestSieveTinyLFUSampleSize(t *testing.T) {
 	highFreqRemaining := 0
 	lowFreqRemaining := 0
 
-	for i := 0; i < 5; i++ { // High frequency items
+	for i := range 5 { // High frequency items
 		if _, found := cache.Get(string(rune('a' + i))); found {
 			highFreqRemaining++
 		}
@@ -371,7 +363,6 @@ func TestSieveTinyLFUSampleSize(t *testing.T) {
 		highFreqRemaining, lowFreqRemaining)
 }
 
-// TestSieveTinyLFUStressEviction tests SieveTinyLFU under heavy eviction pressure
 func TestSieveTinyLFUStressEviction(t *testing.T) {
 	config := Config{
 		MaxSize:        5,
@@ -383,7 +374,6 @@ func TestSieveTinyLFUStressEviction(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Establish a baseline with known access patterns
 	cache.Set("high1", 1, time.Hour)
 	cache.Set("high2", 2, time.Hour)
 	cache.Set("low1", 3, time.Hour)
@@ -391,8 +381,7 @@ func TestSieveTinyLFUStressEviction(t *testing.T) {
 	cache.Set("low3", 5, time.Hour)
 	waitForWrites(t, cache)
 
-	// Create clear frequency distinction
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		cache.Get("high1")
 		cache.Get("high2")
 	}
@@ -404,7 +393,7 @@ func TestSieveTinyLFUStressEviction(t *testing.T) {
 
 	// Force many operations - some will be rejected by admission control
 	admitted := 0
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		evictionsBefore := cache.Stats().Evictions
 		sizeBefore := cache.Stats().Size
 		cache.Set(string(rune('z'+i%26)), 1000+i, time.Hour)
@@ -453,7 +442,6 @@ func TestSieveTinyLFUStressEviction(t *testing.T) {
 	t.Logf("Total evictions: %d, Items admitted: %d", totalEvictions, admitted)
 }
 
-// TestFrequencyAdmissionFilter tests the new frequency-based admission filter
 func TestFrequencyAdmissionFilter(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -465,14 +453,13 @@ func TestFrequencyAdmissionFilter(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache to capacity first
 	cache.Set("victim1", 1, time.Hour) // Low frequency victim
 	cache.Set("victim2", 2, time.Hour) // Low frequency victim
 	cache.Set("victim3", 3, time.Hour) // Low frequency victim
 	waitForWrites(t, cache)
 
 	// Create frequency gradient - access some items more than others
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		cache.Get("victim1") // Higher frequency
 	}
 	cache.Get("victim2") // Medium frequency
@@ -483,7 +470,7 @@ func TestFrequencyAdmissionFilter(t *testing.T) {
 	rejectedCount := 0
 
 	// Test 1: High frequency items should have better admission chances
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		key := fmt.Sprintf("high_freq_%d", i)
 		evictionsBefore := cache.Stats().Evictions
 
@@ -521,7 +508,6 @@ func TestFrequencyAdmissionFilter(t *testing.T) {
 	}
 }
 
-// TestVictimFrequencyTracking tests that victim frequencies are properly tracked
 func TestVictimFrequencyTracking(t *testing.T) {
 	config := Config{
 		MaxSize:        2,
@@ -569,7 +555,6 @@ func TestVictimFrequencyTracking(t *testing.T) {
 	t.Logf("Evictions occurred: %d", finalEvictions-initialEvictions)
 }
 
-// TestFrequencyBasedAdmissionDecisions tests specific admission logic
 func TestFrequencyBasedAdmissionDecisions(t *testing.T) {
 	config := Config{
 		MaxSize:        4,
@@ -581,30 +566,27 @@ func TestFrequencyBasedAdmissionDecisions(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache and establish frequency patterns
 	cache.Set("freq_5", 1, time.Hour)
 	cache.Set("freq_3", 2, time.Hour)
 	cache.Set("freq_1", 3, time.Hour)
 	cache.Set("freq_0", 4, time.Hour)
 	waitForWrites(t, cache)
 
-	// Create frequency gradient
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		cache.Get("freq_5")
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cache.Get("freq_3")
 	}
-	for i := 0; i < 1; i++ {
+	for range 1 {
 		cache.Get("freq_1")
 	}
-	// freq_0 has 0 additional accesses
 
 	// Test admission patterns
 	admissionResults := make(map[string]bool)
 
 	// Try multiple new items to see admission patterns
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		key := fmt.Sprintf("test_%d", i)
 		evictionsBefore := cache.Stats().Evictions
 
@@ -616,7 +598,6 @@ func TestFrequencyBasedAdmissionDecisions(t *testing.T) {
 		admissionResults[key] = admitted
 	}
 
-	// Count admissions
 	admittedCount := 0
 	for _, admitted := range admissionResults {
 		if admitted {
@@ -654,7 +635,6 @@ func TestDoorkeeperBehavior(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache
 	cache.Set("old1", 1, time.Hour)
 	cache.Set("old2", 2, time.Hour)
 	waitForWrites(t, cache)
@@ -668,8 +648,6 @@ func TestDoorkeeperBehavior(t *testing.T) {
 	waitForWrites(t, cache)
 	evictionsAfter := cache.Stats().Evictions
 
-	// The second set should likely cause eviction since repeated keys get priority.
-
 	t.Logf("Evictions before: %d, after: %d", evictionsBefore, evictionsAfter)
 
 	// Verify cache maintains size constraint
@@ -678,7 +656,6 @@ func TestDoorkeeperBehavior(t *testing.T) {
 	}
 }
 
-// TestAdmissionFilterStats tests statistics tracking
 func TestAdmissionFilterStats(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -690,7 +667,6 @@ func TestAdmissionFilterStats(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache to trigger admission filter usage
 	cache.Set("item1", 1, time.Hour)
 	cache.Set("item2", 2, time.Hour)
 	cache.Set("item3", 3, time.Hour)
@@ -700,7 +676,7 @@ func TestAdmissionFilterStats(t *testing.T) {
 
 	// Add more items to trigger admission filter
 	itemsAdded := 0
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		evictionsBefore := cache.Stats().Evictions
 		cache.Set(fmt.Sprintf("new_%d", i), 100+i, time.Hour)
 		waitForWrites(t, cache)
@@ -716,7 +692,6 @@ func TestAdmissionFilterStats(t *testing.T) {
 
 	t.Logf("Items that caused evictions: %d, Total evictions: %d", itemsAdded, totalEvictions)
 
-	// Basic sanity checks
 	if cache.Stats().Size > 3 {
 		t.Errorf("Cache size %d exceeds max capacity 3", cache.Stats().Size)
 	}
@@ -727,7 +702,6 @@ func TestAdmissionFilterStats(t *testing.T) {
 	}
 }
 
-// TestSieveTinyLFUWithFrequencyAdmission tests integration between eviction and admission
 func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 	config := Config{
 		MaxSize:        5,
@@ -739,7 +713,6 @@ func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Establish baseline with known access patterns
 	cache.Set("high1", 1, time.Hour)
 	cache.Set("high2", 2, time.Hour)
 	cache.Set("med1", 3, time.Hour)
@@ -748,19 +721,18 @@ func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 	waitForWrites(t, cache)
 
 	// Create clear frequency differences
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		cache.Get("high1")
 		cache.Get("high2")
 	}
 
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		cache.Get("med1")
 	}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		cache.Get("low1")
 	}
-	// low2 gets no additional accesses
 
 	initialStats := cache.Stats()
 
@@ -768,7 +740,7 @@ func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 	admissionAttempts := 0
 	actualAdmissions := 0
 
-	for i := 0; i < 30; i++ {
+	for i := range 30 {
 		evictionsBefore := cache.Stats().Evictions
 		sizeBefore := cache.Stats().Size
 
@@ -795,7 +767,6 @@ func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 
 	t.Logf("Total evictions: %d", finalStats.Evictions-initialStats.Evictions)
 
-	// Verify cache constraint maintained
 	if finalStats.Size > 5 {
 		t.Errorf("Cache size %d exceeds max capacity 5", finalStats.Size)
 	}
@@ -815,7 +786,6 @@ func TestSieveTinyLFUWithFrequencyAdmission(t *testing.T) {
 	t.Logf("High frequency items surviving: %d/2", highFreqSurvival)
 }
 
-// TestSieveTinyLFUFrequencyThreshold tests frequency-based guaranteed admission
 func TestSieveTinyLFUFrequencyThreshold(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -827,7 +797,6 @@ func TestSieveTinyLFUFrequencyThreshold(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache
 	cache.Set("a", 1, time.Hour)
 	cache.Set("b", 2, time.Hour)
 	cache.Set("c", 3, time.Hour)
@@ -836,7 +805,7 @@ func TestSieveTinyLFUFrequencyThreshold(t *testing.T) {
 	// Create a high-frequency item that should get strong SieveTinyLFU admission priority.
 	cache.Set("high_freq", 100, time.Hour)
 	waitForWrites(t, cache)
-	for i := 0; i < 4; i++ { // Build TinyLFU frequency.
+	for range 4 { // Build TinyLFU frequency.
 		cache.Get("high_freq")
 	}
 
@@ -845,7 +814,7 @@ func TestSieveTinyLFUFrequencyThreshold(t *testing.T) {
 	// Try to add another high-frequency item
 	cache.Set("guaranteed", 200, time.Hour)
 	waitForWrites(t, cache)
-	for i := 0; i < 4; i++ { // Build TinyLFU frequency.
+	for range 4 {
 		cache.Get("guaranteed")
 	}
 
@@ -883,15 +852,13 @@ func TestSieveTinyLFUScanDetection(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache with stable items
 	cache.Set("stable1", 1, time.Hour)
 	cache.Set("stable2", 2, time.Hour)
 	cache.Set("stable3", 3, time.Hour)
 	cache.Set("stable4", 4, time.Hour)
 	waitForWrites(t, cache)
 
-	// Build frequency for stable items
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cache.Get("stable1")
 		cache.Get("stable2")
 		cache.Get("stable3")
@@ -902,7 +869,7 @@ func TestSieveTinyLFUScanDetection(t *testing.T) {
 
 	// Simulate scanning pattern with sequential cold keys.
 	scanRejections := 0
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		key := fmt.Sprintf("scan_%010d", i) // Sequential keys
 		sizeBefore := cache.Size()
 		cache.Set(key, 1000+i, time.Hour)
@@ -934,7 +901,6 @@ func TestSieveTinyLFUScanDetection(t *testing.T) {
 	t.Logf("Surviving stable items: %d/4", survivingStable)
 }
 
-// TestSieveTinyLFURepeatedKeyBehavior tests repeated-key admission behavior.
 func TestSieveTinyLFURepeatedKeyBehavior(t *testing.T) {
 	config := Config{
 		MaxSize:        5,
@@ -946,8 +912,7 @@ func TestSieveTinyLFURepeatedKeyBehavior(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		cache.Set(fmt.Sprintf("init%d", i), i, time.Hour)
 	}
 	waitForWrites(t, cache)
@@ -1002,7 +967,6 @@ func TestSieveTinyLFURepeatedKeyBehavior(t *testing.T) {
 	waitForWrites(t, cache)
 }
 
-// TestSieveTinyLFUAdaptiveProbability tests dynamic probability adjustment
 func TestSieveTinyLFUAdaptiveProbability(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -1014,7 +978,6 @@ func TestSieveTinyLFUAdaptiveProbability(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache
 	cache.Set("a", 1, time.Hour)
 	cache.Set("b", 2, time.Hour)
 	cache.Set("c", 3, time.Hour)
@@ -1029,7 +992,7 @@ func TestSieveTinyLFUAdaptiveProbability(t *testing.T) {
 	admitted := 0
 	rejected := 0
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		key := fmt.Sprintf("pressure%d", i)
 		cache.Set(key, 1000+i, time.Hour)
 		waitForWrites(t, cache)
@@ -1061,7 +1024,6 @@ func TestSieveTinyLFUAdaptiveProbability(t *testing.T) {
 	}
 }
 
-// TestSieveTinyLFURecencyTieBreaking tests recency-based tie breaking
 func TestSieveTinyLFURecencyTieBreaking(t *testing.T) {
 	config := Config{
 		MaxSize:        3,
@@ -1073,13 +1035,11 @@ func TestSieveTinyLFURecencyTieBreaking(t *testing.T) {
 	cache := newTestCache[string, int](t, config)
 	defer cache.Close()
 
-	// Fill cache
 	cache.Set("a", 1, time.Hour)
 	cache.Set("b", 2, time.Hour)
 	cache.Set("c", 3, time.Hour)
 	waitForWrites(t, cache)
 
-	// Create equal frequency scenario
 	cache.Get("a")
 	cache.Get("b")
 	cache.Get("c")
@@ -1109,7 +1069,6 @@ func TestSieveTinyLFURecencyTieBreaking(t *testing.T) {
 
 	t.Logf("Recent items surviving: %d/2", recentSurvival)
 
-	// Verify cache constraints
 	if cache.Size() != 3 {
 		t.Errorf("Cache size should be 3, got %d", cache.Size())
 	}

--- a/ghost.go
+++ b/ghost.go
@@ -1,88 +1,150 @@
 package kioshun
 
+import "github.com/unkn0wn-root/kioshun/internal/keyhash"
+
 // ghostQueue is a fixed size FIFO of recently evicted item fingerprints. A hit
 // is evidence that the queue the item came from was too small for the current
 // workload, so SieveTinyLFU readmits the item directly into main and may grow
 // probation.
 //
 // A fingerprint is the full 64-bit key hash, which identifies an item as
-// precisely as the cache can. contains and add touch the ghost on every
-// admission along the SIEVE eviction path so each entry is kept minimal
-// a bare uint64 mapped to the ring slot that holds it.
+// precisely as the cache can. The ring keeps fingerprints in FIFO order; an
+// open-addressed index maps a fingerprint back to its ring slot so contains,
+// add and remove are O(1). The index is a flat uint32 slice
+// (probe position -> ring slot + 1, 0 meaning empty).
+//
+// All operations run on the single-consumer maintenance path under the shard
+// write lock so the index needs no synchronization. Membership lives in the
+// index, not the ring values, so fingerprint 0 (empty-string and zero-int keys
+// hash to 0) is tracked like any other: a cleared ring slot reads as 0 but is
+// distinguished from a tracked 0 by having no index entry point at it.
 type ghostQueue struct {
-	entries []uint64       // FIFO ring of fingerprints; the index map owns membership
-	index   map[uint64]int // fingerprint -> ring slot for membership
-	next    int
+	entries []uint64
+	slots   []uint32 // probe pos -> ring index + 1 (0 = empty)
+	mask    uint64
+	next    int // FIFO cursor
+	live    int // tracked fingerprints (index entries)
 }
 
-// newGhostQueue returns a disabled zero value when n <= 0, letting callers use
-// contains/add/remove without separate nil-state branches.
 func newGhostQueue(n int) ghostQueue {
 	if n <= 0 {
 		return ghostQueue{}
 	}
 
+	m := max(nextPowerOf2(n*2), 8)
 	return ghostQueue{
 		entries: make([]uint64, n),
-		index:   make(map[uint64]int, n),
+		slots:   make([]uint32, m),
+		mask:    uint64(m - 1),
+	}
+}
+
+// probeStart de-correlates the fingerprint before masking. Within a shard every
+// stored hash shares the same low bits (those select the shard) so masking the
+// raw hash would cluster every entry into one probe chain
+func (g *ghostQueue) probeStart(h uint64) uint64 {
+	return keyhash.Avalanche(h) & g.mask
+}
+
+// idxFind returns the index slot holding fingerprint h and whether it was found.
+// On a miss the returned position is the empty slot that terminated the probe.
+func (g *ghostQueue) idxFind(h uint64) (uint64, bool) {
+	pos := g.probeStart(h)
+	for {
+		v := g.slots[pos]
+		if v == 0 {
+			return pos, false
+		}
+		if g.entries[v-1] == h {
+			return pos, true
+		}
+		pos = (pos + 1) & g.mask
+	}
+}
+
+// idxInsert records that fingerprint h lives at ring index ringIdx.
+func (g *ghostQueue) idxInsert(h uint64, ringIdx int) {
+	pos := g.probeStart(h)
+	for g.slots[pos] != 0 {
+		pos = (pos + 1) & g.mask
+	}
+	g.slots[pos] = uint32(ringIdx) + 1
+}
+
+// idxDeleteAt empties index slot pos then reinserts the rest of that probe
+// cluster so no entry is stranded behind the new hole. Clusters are short at
+// this load factor, and the rehash needs no tombstones.
+func (g *ghostQueue) idxDeleteAt(pos uint64) {
+	g.slots[pos] = 0
+	next := (pos + 1) & g.mask
+	for g.slots[next] != 0 {
+		v := g.slots[next]
+		g.slots[next] = 0
+		g.idxInsert(g.entries[v-1], int(v-1))
+		next = (next + 1) & g.mask
 	}
 }
 
 func (g *ghostQueue) contains(h uint64) bool {
-	if g.index == nil {
+	if len(g.entries) == 0 {
 		return false
 	}
-
-	_, ok := g.index[h]
+	_, ok := g.idxFind(h)
 	return ok
 }
 
-// add records a fingerprint unless it is already present.
-// The ring and index are kept in sync by deleting the overwritten entry only
-// when the index still points at the slot being reused (the entry may have been
+// add records a fingerprint unless it is already present, overwriting the oldest
+// ring slot when the ring is full. The overwritten fingerprint's index entry is
+// dropped only when it still points at the slot being reused (it may have been
 // removed on a ghost hit and re-added at a newer slot since).
 func (g *ghostQueue) add(h uint64) {
 	if len(g.entries) == 0 {
 		return
 	}
-
-	if _, ok := g.index[h]; ok {
+	if _, ok := g.idxFind(h); ok {
 		return
 	}
 
 	old := g.entries[g.next]
-	if i, ok := g.index[old]; ok && i == g.next {
-		delete(g.index, old)
+	if pos, ok := g.idxFind(old); ok && g.slots[pos] == uint32(g.next)+1 {
+		g.idxDeleteAt(pos)
+		g.live--
 	}
 
 	g.entries[g.next] = h
-	g.index[h] = g.next
-	g.next = (g.next + 1) % len(g.entries)
+	g.idxInsert(h, g.next)
+	g.live++
+	g.next++
+	if g.next == len(g.entries) {
+		g.next = 0
+	}
 }
 
-// remove deletes a fingerprint from the index and clears its ring slot if the
-// slot still holds it. The FIFO cursor is not rewound.
+// remove deletes a fingerprint from the index and clears its ring slot.
 func (g *ghostQueue) remove(h uint64) bool {
-	if g.index == nil {
+	if len(g.entries) == 0 {
 		return false
 	}
 
-	i, ok := g.index[h]
+	pos, ok := g.idxFind(h)
 	if !ok {
 		return false
 	}
 
-	delete(g.index, h)
-	if i >= 0 && i < len(g.entries) && g.entries[i] == h {
-		g.entries[i] = 0
-	}
+	ringIdx := g.slots[pos] - 1
+	g.idxDeleteAt(pos)
+	g.live--
+	g.entries[ringIdx] = 0
 	return true
 }
+
+func (g *ghostQueue) count() int { return g.live }
 
 // clear preserves the allocated ring and index so policy reset does not force
 // the next fill cycle to reallocate ghost storage.
 func (g *ghostQueue) clear() {
 	clear(g.entries)
-	clear(g.index)
+	clear(g.slots)
 	g.next = 0
+	g.live = 0
 }

--- a/ghost.go
+++ b/ghost.go
@@ -1,18 +1,17 @@
 package kioshun
 
-// ghostEntry stores a compact item identity. The tag is kept with the hash to
-// reduce false ghost hits without retaining full keys after eviction.
-type ghostEntry struct {
-	hash uint64
-	tag  uint16
-}
-
-// ghostQueue is a fixed size FIFO of recently evicted probation fingerprints.
-// A hit is evidence that probation was too small for the current workload, so
-// SieveTinyLFU readmits the item directly into main and may grow probation.
+// ghostQueue is a fixed size FIFO of recently evicted item fingerprints. A hit
+// is evidence that the queue the item came from was too small for the current
+// workload, so SieveTinyLFU readmits the item directly into main and may grow
+// probation.
+//
+// A fingerprint is the full 64-bit key hash, which identifies an item as
+// precisely as the cache can. contains and add touch the ghost on every
+// admission along the SIEVE eviction path so each entry is kept minimal
+// a bare uint64 mapped to the ring slot that holds it.
 type ghostQueue struct {
-	entries []ghostEntry
-	index   map[ghostEntry]int
+	entries []uint64       // FIFO ring of fingerprints; the index map owns membership
+	index   map[uint64]int // fingerprint -> ring slot for membership
 	next    int
 }
 
@@ -24,33 +23,30 @@ func newGhostQueue(n int) ghostQueue {
 	}
 
 	return ghostQueue{
-		entries: make([]ghostEntry, n),
-		index:   make(map[ghostEntry]int, n),
+		entries: make([]uint64, n),
+		index:   make(map[uint64]int, n),
 	}
 }
 
-func (g *ghostQueue) contains(h uint64, t uint16) bool {
+func (g *ghostQueue) contains(h uint64) bool {
 	if g.index == nil {
 		return false
 	}
 
-	_, ok := g.index[ghostEntry{hash: h, tag: t}]
+	_, ok := g.index[h]
 	return ok
 }
 
 // add records a fingerprint unless it is already present.
 // The ring and index are kept in sync by deleting the overwritten entry only
-// when the index still points at the slot being reused.
-func (g *ghostQueue) add(h uint64, t uint16) {
+// when the index still points at the slot being reused (the entry may have been
+// removed on a ghost hit and re-added at a newer slot since).
+func (g *ghostQueue) add(h uint64) {
 	if len(g.entries) == 0 {
 		return
 	}
 
-	e := ghostEntry{hash: h, tag: t}
-	if g.index == nil {
-		g.index = make(map[ghostEntry]int, len(g.entries))
-	}
-	if _, ok := g.index[e]; ok {
+	if _, ok := g.index[h]; ok {
 		return
 	}
 
@@ -59,27 +55,26 @@ func (g *ghostQueue) add(h uint64, t uint16) {
 		delete(g.index, old)
 	}
 
-	g.entries[g.next] = e
-	g.index[e] = g.next
+	g.entries[g.next] = h
+	g.index[h] = g.next
 	g.next = (g.next + 1) % len(g.entries)
 }
 
-// remove deletes a fingerprint from the index and clears its slot if the slot
-// still contains that exact entry. The FIFO cursor is not rewound.
-func (g *ghostQueue) remove(h uint64, t uint16) bool {
+// remove deletes a fingerprint from the index and clears its ring slot if the
+// slot still holds it. The FIFO cursor is not rewound.
+func (g *ghostQueue) remove(h uint64) bool {
 	if g.index == nil {
 		return false
 	}
 
-	e := ghostEntry{hash: h, tag: t}
-	i, ok := g.index[e]
+	i, ok := g.index[h]
 	if !ok {
 		return false
 	}
 
-	delete(g.index, e)
-	if i >= 0 && i < len(g.entries) && g.entries[i] == e {
-		g.entries[i] = ghostEntry{}
+	delete(g.index, h)
+	if i >= 0 && i < len(g.entries) && g.entries[i] == h {
+		g.entries[i] = 0
 	}
 	return true
 }

--- a/ghost_test.go
+++ b/ghost_test.go
@@ -1,0 +1,138 @@
+package kioshun
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type refGhost struct {
+	entries []uint64
+	index   map[uint64]int
+	next    int
+}
+
+func newRefGhost(n int) refGhost {
+	if n <= 0 {
+		return refGhost{}
+	}
+	return refGhost{entries: make([]uint64, n), index: make(map[uint64]int, n)}
+}
+
+func (g *refGhost) contains(h uint64) bool {
+	if g.index == nil {
+		return false
+	}
+	_, ok := g.index[h]
+	return ok
+}
+
+func (g *refGhost) add(h uint64) {
+	if len(g.entries) == 0 {
+		return
+	}
+	if _, ok := g.index[h]; ok {
+		return
+	}
+	old := g.entries[g.next]
+	if i, ok := g.index[old]; ok && i == g.next {
+		delete(g.index, old)
+	}
+	g.entries[g.next] = h
+	g.index[h] = g.next
+	g.next = (g.next + 1) % len(g.entries)
+}
+
+func (g *refGhost) remove(h uint64) bool {
+	if g.index == nil {
+		return false
+	}
+	i, ok := g.index[h]
+	if !ok {
+		return false
+	}
+	delete(g.index, h)
+	if i >= 0 && i < len(g.entries) && g.entries[i] == h {
+		g.entries[i] = 0
+	}
+	return true
+}
+
+func TestGhostBasic(t *testing.T) {
+	g := newGhostQueue(4)
+
+	if g.contains(10) {
+		t.Fatal("empty ghost should not contain 10")
+	}
+	g.add(10)
+	g.add(20)
+	g.add(30)
+	g.add(40)
+	if !g.contains(10) || !g.contains(40) {
+		t.Fatal("expected 10..40 present in a full cap-4 ring")
+	}
+	// dedup: re-adding a present fingerprint is a no-op (does not refresh recency).
+	g.add(10)
+	// fifth distinct insert evicts the oldest live fingerprint (10), not the
+	// re-added one - the dedup did not advance the FIFO cursor.
+	g.add(50)
+	if g.contains(10) {
+		t.Fatal("10 should have been FIFO-evicted")
+	}
+	if !g.contains(50) || !g.contains(40) || !g.contains(30) || !g.contains(20) {
+		t.Fatal("20,30,40,50 expected present")
+	}
+	// remove frees membership.
+	if !g.remove(20) || g.contains(20) {
+		t.Fatal("remove(20) should drop it")
+	}
+	if g.remove(99) {
+		t.Fatal("remove of absent returns false")
+	}
+	g.clear()
+	if g.contains(30) || g.contains(50) {
+		t.Fatal("clear should empty membership")
+	}
+}
+
+func TestGhostDisabled(t *testing.T) {
+	g := newGhostQueue(0)
+	g.add(1)
+	if g.contains(1) || g.remove(1) {
+		t.Fatal("disabled ghost must stay empty")
+	}
+	g.clear()
+}
+
+func TestGhostDifferentialFuzz(t *testing.T) {
+	for _, n := range []int{1, 2, 3, 7, 8, 16, 64} {
+		for seed := range int64(40) {
+			r := rand.New(rand.NewSource(seed*1000 + int64(n)))
+			g := newGhostQueue(n)
+			ref := newRefGhost(n)
+			// Small fingerprint domain forces frequent collisions, dedups and
+			// re-adds of evicted keys - the corner cases of the ring/index dance.
+			dom := uint64(n*3 + 2)
+			for step := range 2000 {
+				h := uint64(r.Intn(int(dom))) // includes 0: a real, trackable fingerprint
+				switch r.Intn(3) {
+				case 0, 1:
+					g.add(h)
+					ref.add(h)
+				case 2:
+					if g.remove(h) != ref.remove(h) {
+						t.Fatalf("n=%d seed=%d step=%d remove(%d) mismatch", n, seed, step, h)
+					}
+				}
+				// Full-domain membership cross-check every few steps.
+				if step%7 == 0 {
+					for q := uint64(0); q <= dom+1; q++ {
+						if g.contains(q) != ref.contains(q) {
+							t.Fatalf("n=%d seed=%d step=%d contains(%d): got %v want %v",
+								n, seed, step, q, g.contains(q), ref.contains(q))
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/htable.go
+++ b/htable.go
@@ -1,0 +1,281 @@
+package kioshun
+
+import "sync/atomic"
+
+// htable is the per-shard key/value store: a single-writer/multi-reader
+// open-addressing hash table with lock-free reads.
+//
+// Reads (lookup) take no lock - they snapshot the slot array and linear probe a
+// dense array of co-located {tag, item} cells, dereferencing an item only
+// on a tag match. Safety of lock-free reads rests on item immutability:
+// a reader may still hold an item the writer has evicted,
+// so reader-visible item fields (key, hash, value, expireTime) are written
+// before the item is published and never mutated afterwards;
+// a value update allocates a fresh item and swaps it in.
+type htable[K comparable, V any] struct {
+	data  atomic.Pointer[htableData[K, V]]
+	live  int // writer-only
+	tombs int // writer-only
+}
+
+// htslot is one co-located cell. tag pre-filters probes without dereferencing
+// the item: 0 = empty (a lookup stops), 1 = tombstone (a lookup continues past
+// it), any other value = the slot's normalized item hash.
+// Publication order makes a matching tag imply a readable item: store writes the
+// item pointer before the tag, and remove writes the tombstone tag before
+// clearing the pointer.
+type htslot[K comparable, V any] struct {
+	tag  atomic.Uint64
+	item atomic.Pointer[cacheItem[K, V]]
+}
+
+type htableData[K comparable, V any] struct {
+	slots []htslot[K, V]
+	mask  uint64
+}
+
+const (
+	htMinSlots = 8
+	// rehash/grow when (live+tombs)/slots reaches 3/4. Open addressing degrades
+	// sharply past this load and probes walk tombstones until then.
+	htLoadNum = 3
+	htLoadDen = 4
+)
+
+func newHtable[K comparable, V any](capacityHint int) *htable[K, V] {
+	n := max(nextPowerOf2(capacityHint*2), htMinSlots)
+	t := &htable[K, V]{}
+	t.data.Store(&htableData[K, V]{slots: make([]htslot[K, V], n), mask: uint64(n - 1)})
+	return t
+}
+
+// htNormHash keeps stored tags out of the 0 (empty) and 1 (tombstone) sentinel
+// space. A real avalanche hash hitting {0,1} is vanishingly unlikely; remapping
+// it only risks an extra key comparison, never incorrectness.
+func htNormHash(h uint64) uint64 {
+	if h < 2 {
+		return h + 2
+	}
+	return h
+}
+
+func (t *htable[K, V]) lookup(hash uint64, key K) (*cacheItem[K, V], bool) {
+	tag := htNormHash(hash)
+	d := t.data.Load()
+	i := tag & d.mask
+	for {
+		s := &d.slots[i]
+		switch s.tag.Load() {
+		case 0:
+			return nil, false
+		case tag:
+			if it := s.item.Load(); it != nil && it.key == key {
+				return it, true
+			}
+		}
+		i = (i + 1) & d.mask
+	}
+}
+
+func (t *htable[K, V]) store(it *cacheItem[K, V]) (prev *cacheItem[K, V]) {
+	tag := htNormHash(it.hash)
+	d := t.data.Load()
+	i := tag & d.mask
+	firstTomb := -1
+	for {
+		s := &d.slots[i]
+		switch s.tag.Load() {
+		case 0:
+			// key absent (probed to an empty slot): insert, reusing the first
+			// tombstone seen on the way if there was one.
+			dst := s
+			if firstTomb >= 0 {
+				dst = &d.slots[firstTomb]
+				t.tombs--
+			}
+			dst.item.Store(it)
+			dst.tag.Store(tag)
+			t.live++
+			t.maybeGrow()
+			return nil
+		case 1:
+			if firstTomb < 0 {
+				firstTomb = int(i)
+			}
+		case tag:
+			if cur := s.item.Load(); cur != nil && cur.key == it.key {
+				s.item.Store(it) // same tag, swap the value-carrying item
+				return cur
+			}
+		}
+		i = (i + 1) & d.mask
+	}
+}
+
+// htCursor captures where a deferred insert will be published. It is produced by
+// probe and consumed by publish under the same shard write lock; the captured
+// htableData pointer lets publish detect (and fall back from) a rehash that
+// happened in between, though eviction never rehashes today.
+type htCursor[K comparable, V any] struct {
+	d    *htableData[K, V]
+	slot uint64
+	tomb bool // the slot was a tombstone at probe time (publish reclaims it)
+}
+
+// probe walks for it.key in one pass. If the key already exists, it swaps the
+// value-carrying item in place (publishing the new immutable item) and returns
+// prev != nil - an update completed without a second walk. If the key is absent,
+// it returns prev=nil plus a cursor at the slot a later publish should fill,
+// WITHOUT inserting, so a SieveTinyLFU candidate can run admission before it ever
+// becomes visible to lock-free readers. Caller holds the shard write lock.
+//
+// This is store's probe walk - the same tag sentinels and first-tombstone reuse -
+// diverging only at the empty slot, where store commits in place and probe defers
+// to publish. The two walks must stay in sync: a change to tombstone reuse or tag
+// handling here belongs in store (and the read-only walks in lookup/removeExact)
+// too.
+func (t *htable[K, V]) probe(it *cacheItem[K, V]) (prev *cacheItem[K, V], cur htCursor[K, V]) {
+	tag := htNormHash(it.hash)
+	d := t.data.Load()
+	i := tag & d.mask
+	firstTomb := -1
+	for {
+		s := &d.slots[i]
+		switch s.tag.Load() {
+		case 0:
+			slot, tomb := i, false
+			if firstTomb >= 0 {
+				slot, tomb = uint64(firstTomb), true
+			}
+			return nil, htCursor[K, V]{d: d, slot: slot, tomb: tomb}
+		case 1:
+			if firstTomb < 0 {
+				firstTomb = int(i)
+			}
+		case tag:
+			if cur := s.item.Load(); cur != nil && cur.key == it.key {
+				s.item.Store(it) // same tag, swap the value-carrying item
+				return cur, htCursor[K, V]{}
+			}
+		}
+		i = (i + 1) & d.mask
+	}
+}
+
+// publish completes a deferred insert at cur, mirroring store's empty-slot arm.
+// If the table was rehashed or cleared since probe (defensive: eviction never
+// rehashes), the cursor is stale, so it falls back to a full store.
+func (t *htable[K, V]) publish(it *cacheItem[K, V], cur htCursor[K, V]) {
+	if cur.d != t.data.Load() {
+		t.store(it)
+		return
+	}
+	s := &cur.d.slots[cur.slot]
+	s.item.Store(it)
+	s.tag.Store(htNormHash(it.hash))
+	t.live++
+	if cur.tomb {
+		t.tombs--
+	}
+	t.maybeGrow()
+}
+
+// removeExact tombstones the slot only if it still holds exactly it, returning
+// whether it did. The identity check rejects stale hand/queue pointers whose
+// slot another mutation already replaced or removed.
+func (t *htable[K, V]) removeExact(it *cacheItem[K, V]) bool {
+	tag := htNormHash(it.hash)
+	d := t.data.Load()
+	i := tag & d.mask
+	for {
+		s := &d.slots[i]
+		switch s.tag.Load() {
+		case 0:
+			return false
+		case tag:
+			if s.item.Load() == it {
+				s.tag.Store(1)
+				s.item.Store(nil)
+				t.live--
+				t.tombs++
+				return true
+			}
+		}
+		i = (i + 1) & d.mask
+	}
+}
+
+func (t *htable[K, V]) length() int { return t.live }
+
+func (t *htable[K, V]) forEach(fn func(*cacheItem[K, V]) bool) {
+	d := t.data.Load()
+	for i := range d.slots {
+		if d.slots[i].tag.Load() <= 1 {
+			continue
+		}
+		if it := d.slots[i].item.Load(); it != nil {
+			if !fn(it) {
+				return
+			}
+		}
+	}
+}
+
+// clear publishes a fresh empty table of the same size. In-flight readers keep
+// reading their old immutable snapshot until they finish.
+func (t *htable[K, V]) clear() {
+	d := t.data.Load()
+	n := len(d.slots)
+	t.data.Store(&htableData[K, V]{slots: make([]htslot[K, V], n), mask: uint64(n - 1)})
+	t.live = 0
+	t.tombs = 0
+}
+
+// maybeGrow rehashes when the table is too full. A table dense with live items
+// grows; one merely full of tombstones is rebuilt at the same size to reclaim
+// them.
+func (t *htable[K, V]) maybeGrow() {
+	d := t.data.Load()
+	n := len(d.slots)
+	if (t.live+t.tombs)*htLoadDen < n*htLoadNum {
+		return
+	}
+
+	newN := n
+	if t.live*htLoadDen >= n*htLoadNum {
+		newN = n * 2
+	}
+	t.rehash(newN)
+}
+
+// rehash rebuilds the slot array at newN slots dropping tombstones, then
+// publishes it atomically so a concurrent reader observes either the complete
+// old table or the complete new one.
+func (t *htable[K, V]) rehash(newN int) {
+	d := t.data.Load()
+	nd := &htableData[K, V]{slots: make([]htslot[K, V], newN), mask: uint64(newN - 1)}
+	live := 0
+	for i := range d.slots {
+		if d.slots[i].tag.Load() <= 1 {
+			continue
+		}
+
+		it := d.slots[i].item.Load()
+		if it == nil {
+			continue
+		}
+
+		tag := htNormHash(it.hash)
+		j := tag & nd.mask
+		for nd.slots[j].tag.Load() != 0 {
+			j = (j + 1) & nd.mask
+		}
+
+		nd.slots[j].item.Store(it)
+		nd.slots[j].tag.Store(tag)
+		live++
+	}
+	t.data.Store(nd)
+	t.live = live
+	t.tombs = 0
+}

--- a/htable_test.go
+++ b/htable_test.go
@@ -1,0 +1,102 @@
+package kioshun
+
+import "testing"
+
+func htItem(key, hash int) *cacheItem[int, int] {
+	return &cacheItem[int, int]{key: key, hash: uint64(hash), value: key}
+}
+
+func TestHtableProbeDefersInsert(t *testing.T) {
+	tab := newHtable[int, int](8)
+	it := htItem(1, 100)
+
+	prev, cur := tab.probe(it)
+	if prev != nil {
+		t.Fatalf("probe of absent key returned prev=%p", prev)
+	}
+	if _, ok := tab.lookup(it.hash, it.key); ok {
+		t.Fatal("probe published the item; it must defer until publish")
+	}
+	if tab.live != 0 || tab.tombs != 0 {
+		t.Fatalf("probe mutated table: live=%d tombs=%d", tab.live, tab.tombs)
+	}
+
+	tab.publish(it, cur)
+	got, ok := tab.lookup(it.hash, it.key)
+	if !ok || got != it {
+		t.Fatal("publish did not store the probed item")
+	}
+	if tab.live != 1 {
+		t.Fatalf("live=%d after publish, want 1", tab.live)
+	}
+}
+
+func TestHtableProbeUpdatesInPlace(t *testing.T) {
+	tab := newHtable[int, int](8)
+	old := htItem(1, 100)
+	tab.store(old)
+
+	nw := htItem(1, 100)
+	prev, cur := tab.probe(nw)
+	if prev != old {
+		t.Fatalf("probe update returned prev=%p, want old=%p", prev, old)
+	}
+	if cur.d != nil {
+		t.Fatal("update path must not return an insert cursor")
+	}
+	if got, _ := tab.lookup(nw.hash, nw.key); got != nw {
+		t.Fatal("probe did not swap to the new item")
+	}
+	if tab.live != 1 {
+		t.Fatalf("live=%d after in-place update, want 1", tab.live)
+	}
+}
+
+func TestHtablePublishReclaimsTombstone(t *testing.T) {
+	tab := newHtable[int, int](8) // 16 slots, mask 15
+	a := htItem(1, 16)            // slot 0
+	b := htItem(2, 32)            // collides to slot 0, lands at slot 1
+	tab.store(a)
+	tab.store(b)
+	if !tab.removeExact(a) {
+		t.Fatal("removeExact(a) failed")
+	}
+	if tab.tombs != 1 {
+		t.Fatalf("tombs=%d after removing a, want 1", tab.tombs)
+	}
+
+	c := htItem(3, 48) // collides to slot 0; probe should target the tombstone
+	prev, cur := tab.probe(c)
+	if prev != nil {
+		t.Fatal("c must be absent")
+	}
+	if !cur.tomb {
+		t.Fatal("cursor should target the reclaimable tombstone")
+	}
+	tab.publish(c, cur)
+	if tab.tombs != 0 {
+		t.Fatalf("tombs=%d after reclaim, want 0", tab.tombs)
+	}
+	if got, ok := tab.lookup(c.hash, c.key); !ok || got != c {
+		t.Fatal("c not findable after publish")
+	}
+	if _, ok := tab.lookup(b.hash, b.key); !ok {
+		t.Fatal("b became unreachable after reclaiming the tombstone before it")
+	}
+}
+
+func TestHtablePublishGuardFallsBackAfterRehash(t *testing.T) {
+	tab := newHtable[int, int](8)
+	it := htItem(1, 100)
+
+	_, cur := tab.probe(it)
+	tab.clear() // publishes a fresh slot array; cur.d is now stale
+
+	tab.publish(it, cur)
+	if got, ok := tab.lookup(it.hash, it.key); !ok || got != it {
+		t.Fatal("publish did not fall back to store after the table was replaced")
+	}
+	if tab.live != 1 {
+		t.Fatalf("live=%d after fallback publish, want 1", tab.live)
+	}
+}

--- a/item.go
+++ b/item.go
@@ -10,12 +10,12 @@ type cacheItem[K comparable, V any] struct {
 	expireTime int64 // absolute ns; 0 => no expiration
 	lastAccess int64 // last touch time (ns) for policies that use it
 	lfuFreq    int64 // exact LFU counter
+	cost       int64 // weigher-reported capacity cost;
 	prev       *cacheItem[K, V]
 	next       *cacheItem[K, V]
 	sieveQ     *sieveQueue[K, V]
 	key        K // original key for deletions
 	hash       uint64
-	tag        uint16
 	queue      sieveQueueID
 	reuse      uint8
 	visited    uint32

--- a/item.go
+++ b/item.go
@@ -1,36 +1,25 @@
 package kioshun
 
-import "sync"
-
-// cacheItem is the entry stored in shard.data. It carries value/expiry metadata
-// plus the links and policy state used by LRU, LFU and SieveTinyLFU so policy
-// maintenance does not allocate wrapper nodes.
+// cacheItem is the entry stored in the shard table. It carries value/expiry
+// metadata plus the links and policy state used by LRU, LFU and SieveTinyLFU so
+// policy maintenance does not allocate wrapper nodes.
+//
+// Reader-visible fields (key, hash, value, expireTime) are written before the
+// item is published into the table and never mutated afterwards: lock-free reads
+// may hold an item past its eviction so a value update allocates a fresh item
+// rather than mutating in place, and evicted items are reclaimed by the GC rather
+// than pooled.
 type cacheItem[K comparable, V any] struct {
-	value      V
-	expireTime int64 // absolute ns; 0 => no expiration
-	lastAccess int64 // last touch time (ns) for policies that use it
-	lfuFreq    int64 // exact LFU counter
-	cost       int64 // weigher-reported capacity cost;
-	prev       *cacheItem[K, V]
-	next       *cacheItem[K, V]
-	sieveQ     *sieveQueue[K, V]
-	key        K // original key for deletions
-	hash       uint64
-	queue      sieveQueueID
-	reuse      uint8
-	visited    uint32
-}
-
-func acquireCacheItem[K comparable, V any](pool *sync.Pool) *cacheItem[K, V] {
-	it := pool.Get().(*cacheItem[K, V])
-	*it = cacheItem[K, V]{}
-	return it
-}
-
-func releaseCacheItem[K comparable, V any](pool *sync.Pool, it *cacheItem[K, V]) {
-	if it == nil {
-		return
-	}
-	*it = cacheItem[K, V]{}
-	pool.Put(it)
+	value       V
+	expireTime  int64 // absolute ns; 0 => no expiration
+	cost        int64 // weigher-reported capacity cost;
+	prev        *cacheItem[K, V]
+	next        *cacheItem[K, V]
+	key         K // original key for deletions
+	hash        uint64
+	queue       sieveQueueID // which SIEVE queue role owns this (queueNone = unlinked)
+	queueOwner  uint8
+	reuse       uint8
+	unpublished bool
+	visited     uint32
 }

--- a/lfu.go
+++ b/lfu.go
@@ -29,7 +29,6 @@ func newLFUList[K comparable, V any]() *lfuList[K, V] {
 }
 
 func (l *lfuList[K, V]) add(item *cacheItem[K, V]) {
-	item.lfuFreq = 1
 	node := l.ensureIndex(l.head, 1)
 	node.items[item] = struct{}{}
 	l.itemFreq[item] = node
@@ -55,7 +54,6 @@ func (l *lfuList[K, V]) increment(item *cacheItem[K, V]) {
 	}
 	target.items[item] = struct{}{}
 	l.itemFreq[item] = target
-	item.lfuFreq = newFreq
 
 	if len(cur.items) == 0 && cur.freq != 0 {
 		l.removeFreqNode(cur)

--- a/manager.go
+++ b/manager.go
@@ -141,7 +141,7 @@ func createCache[K comparable, V any](
 	}
 
 	if actual, loaded := m.caches.LoadOrStore(name, cache); loaded {
-		cache.Close()
+		_ = cache.Close()
 		return assertCache[K, V](name, actual)
 	}
 	return cache, nil

--- a/manager.go
+++ b/manager.go
@@ -3,6 +3,7 @@ package kioshun
 import (
 	"errors"
 	"io"
+	"reflect"
 	"sync"
 )
 
@@ -15,22 +16,28 @@ type statser interface {
 	Stats() Stats
 }
 
+type cacheRegistration struct {
+	config    Config
+	cacheType reflect.Type
+	factory   func() (any, error)
+}
+
 // Manager owns named cache instances and their registered configurations.
 type Manager struct {
-	caches   sync.Map // name -> *Cache[K, V]; each name is written once, read many.
-	configs  map[string]Config
-	configMu sync.RWMutex
+	caches        sync.Map // name -> *Cache[K, V]; each name is written once, read many.
+	registrations map[string]cacheRegistration
+	configMu      sync.RWMutex
 }
 
 // NewManager returns an empty Manager with no registered configurations or caches.
 func NewManager() *Manager {
 	return &Manager{
-		configs: make(map[string]Config),
+		registrations: make(map[string]cacheRegistration),
 	}
 }
 
 // Register registers a configuration for a named cache.
-// A name is bound to its configuration by the first GetCache call, so
+// A name is bound to its configuration by the first GetCache call so
 // registering a name that already has a live cache does not change that
 // instance; register before first use.
 func (m *Manager) Register(name string, config Config) error {
@@ -38,14 +45,36 @@ func (m *Manager) Register(name string, config Config) error {
 		return newCacheError("register", name, err)
 	}
 
+	return m.register(name, cacheRegistration{config: config})
+}
+
+// RegisterCache registers a typed cache factory for a named cache. Use this when
+// the cache needs typed options such as WithWeigher, WithOnRemove or WithOnEvict.
+func RegisterCache[K comparable, V any](m *Manager, name string, config Config, opts ...Option[K, V]) error {
+	if err := config.Validate(); err != nil {
+		return newCacheError("register", name, err)
+	}
+
+	opts = append([]Option[K, V](nil), opts...)
+	reg := cacheRegistration{
+		config:    config,
+		cacheType: cacheTypeOf[K, V](),
+		factory: func() (any, error) {
+			return New[K, V](config, opts...)
+		},
+	}
+	return m.register(name, reg)
+}
+
+func (m *Manager) register(name string, reg cacheRegistration) error {
 	m.configMu.Lock()
 	defer m.configMu.Unlock()
 
-	if _, exists := m.configs[name]; exists {
+	if _, exists := m.registrations[name]; exists {
 		return newCacheError("register", name, ErrCacheExists)
 	}
 
-	m.configs[name] = config
+	m.registrations[name] = reg
 	return nil
 }
 
@@ -57,33 +86,60 @@ func GetCache[K comparable, V any](m *Manager, name string) (*Cache[K, V], error
 	}
 
 	m.configMu.RLock()
-	config, exists := m.configs[name]
+	reg, exists := m.registrations[name]
 	m.configMu.RUnlock()
 
 	if !exists {
-		config = DefaultConfig()
+		reg = cacheRegistration{config: DefaultConfig()}
+	} else if reg.cacheType != nil && reg.cacheType != cacheTypeOf[K, V]() {
+		return nil, newCacheError("get", name, ErrTypeMismatch)
 	}
 
-	return createCache[K, V](m, name, config)
+	return createCache[K, V](m, name, reg)
 }
 
 // GetCacheWithConfig returns the named typed cache, creating it from config when
 // it does not yet exist, and needs no prior Register call. If the cache already
 // exists the existing instance is returned and config is ignored (get-or-create).
-func GetCacheWithConfig[K comparable, V any](m *Manager, name string, config Config) (*Cache[K, V], error) {
+func GetCacheWithConfig[K comparable, V any](
+	m *Manager,
+	name string,
+	config Config,
+	opts ...Option[K, V],
+) (*Cache[K, V], error) {
 	if cached, ok := m.caches.Load(name); ok {
 		return assertCache[K, V](name, cached)
 	}
-	return createCache[K, V](m, name, config)
+	return createCache[K, V](m, name, cacheRegistration{config: config}, opts...)
 }
 
 // createCache builds a cache from config and races to publish it under name.
 // LoadOrStore closes the loser of a concurrent create so its workers do not leak.
-func createCache[K comparable, V any](m *Manager, name string, config Config) (*Cache[K, V], error) {
-	cache, err := New[K, V](config)
+func createCache[K comparable, V any](
+	m *Manager,
+	name string,
+	reg cacheRegistration,
+	opts ...Option[K, V],
+) (*Cache[K, V], error) {
+	var created any
+	var err error
+	if reg.factory != nil {
+		created, err = reg.factory()
+	} else {
+		created, err = New[K, V](reg.config, opts...)
+	}
 	if err != nil {
 		return nil, newCacheError("get", name, err)
 	}
+
+	cache, ok := created.(*Cache[K, V])
+	if !ok {
+		if closer, ok := created.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		return nil, newCacheError("get", name, ErrTypeMismatch)
+	}
+
 	if actual, loaded := m.caches.LoadOrStore(name, cache); loaded {
 		cache.Close()
 		return assertCache[K, V](name, actual)
@@ -96,6 +152,10 @@ func assertCache[K comparable, V any](name string, cached any) (*Cache[K, V], er
 		return cache, nil
 	}
 	return nil, newCacheError("get", name, ErrTypeMismatch)
+}
+
+func cacheTypeOf[K comparable, V any]() reflect.Type {
+	return reflect.TypeFor[*Cache[K, V]]()
 }
 
 // Stats returns performance statistics for all managed caches.
@@ -135,7 +195,7 @@ func (m *Manager) CloseAll() error {
 // configuration.
 func (m *Manager) Remove(name string) error {
 	m.configMu.Lock()
-	delete(m.configs, name)
+	delete(m.registrations, name)
 	m.configMu.Unlock()
 
 	if cached, ok := m.caches.LoadAndDelete(name); ok {
@@ -152,11 +212,26 @@ func RegisterGlobalCache(name string, config Config) error {
 	return globalManager.Register(name, config)
 }
 
+// RegisterGlobalTypedCache registers a typed cache factory in the global manager.
+func RegisterGlobalTypedCache[K comparable, V any](name string, config Config, opts ...Option[K, V]) error {
+	return RegisterCache[K, V](globalManager, name, config, opts...)
+}
+
 // GetGlobalCache retrieves or creates a cache from the global manager. Caches
 // created this way live for the lifetime of the process unless released with
 // CloseAllGlobalCaches.
 func GetGlobalCache[K comparable, V any](name string) (*Cache[K, V], error) {
 	return GetCache[K, V](globalManager, name)
+}
+
+// GetGlobalCacheWithConfig retrieves or creates a global cache from config and
+// typed options when it does not yet exist.
+func GetGlobalCacheWithConfig[K comparable, V any](
+	name string,
+	config Config,
+	opts ...Option[K, V],
+) (*Cache[K, V], error) {
+	return GetCacheWithConfig[K, V](globalManager, name, config, opts...)
 }
 
 // GetGlobalCacheStats returns stats for all caches in the global manager.

--- a/queue.go
+++ b/queue.go
@@ -26,8 +26,7 @@ func signal(ch chan struct{}) {
 	}
 }
 
-// mpscCell is one ring slot. seq sequences ownership between producers and the
-// consumer (Vyukov bounded queue); cmd carries the payload in place.
+// mpscCell is one ring slot. seq sequences ownership between producers and the consumer
 type mpscCell[K comparable, V any] struct {
 	seq atomic.Uint64
 	cmd writeCommand[K, V]

--- a/queue.go
+++ b/queue.go
@@ -5,19 +5,6 @@ import "sync/atomic"
 // cacheLinePadding isolates contended atomics onto their own cache lines.
 const cacheLinePadding = 64
 
-// writeQueue connects cache producers to a shard's single write worker.
-// It is multi-producer/single-consumer and applies back-pressure instead of
-// dropping writes; on shutdown it must wake blocked producers.
-type writeQueue[K comparable, V any] interface {
-	enqueue(cmd writeCommand[K, V]) error
-	tryDequeue(buf []writeCommand[K, V]) int
-	quiescent() bool
-}
-
-func newWriteQueue[K comparable, V any](size int, wake chan struct{}, closeCh <-chan struct{}) writeQueue[K, V] {
-	return newMPSCQueue[K, V](size, wake, closeCh)
-}
-
 // signal performs wake on a size-1 channel:
 // if a token is already pending the wake is a no-op.
 func signal(ch chan struct{}) {
@@ -33,8 +20,11 @@ type mpscCell[K comparable, V any] struct {
 	cmd writeCommand[K, V]
 }
 
-// mpscQueue is a bounded Vyukov MPSC ring. Sequence numbers distinguish free,
-// published and stale slots across laps without a producer-side lock.
+// mpscQueue connects cache producers to a shard's single write worker. It is a
+// bounded Vyukov MPSC ring: sequence numbers distinguish free, published and
+// stale slots across laps without a producer-side lock. The queue applies
+// back-pressure instead of dropping writes; on shutdown it wakes blocked
+// producers.
 type mpscQueue[K comparable, V any] struct {
 	mask    uint64
 	buffer  []mpscCell[K, V]
@@ -45,7 +35,7 @@ type mpscQueue[K comparable, V any] struct {
 	_    [cacheLinePadding]byte
 	head atomic.Uint64 // hot
 	_    [cacheLinePadding]byte
-	tail uint64 // single consumer
+	tail atomic.Uint64 // single writer (the consumer)
 	_    [cacheLinePadding]byte
 }
 
@@ -95,30 +85,31 @@ func (q *mpscQueue[K, V]) enqueue(cmd writeCommand[K, V]) error {
 	}
 }
 
-// quiescent reports whether the queue holds no in-flight writes. head == tail
-// means every reserved slot has been consumed, so there is neither a published
+// quiescent reports whether the queue holds no in-flight writes: head == tail
+// means every reserved slot has been consumed so there is neither a published
 // command waiting nor a slot a producer has reserved (advanced head) but not yet
-// published. It is a single-consumer check: the caller must hold the shard drain
-// token so tail is stable. A producer may reserve a slot right after this returns;
-// that write then drains after any inline apply the caller performs, preserving
-// accept order.
+// published. Both ends are read atomically, so this is safe to call without the
+// drain token (e.g. on the lock-free read miss path) - it is only a hint: a
+// producer may reserve a slot, or the consumer may advance tail, right after it
+// returns, which the caller re-checks under the drain token before acting.
 func (q *mpscQueue[K, V]) quiescent() bool {
-	return q.head.Load() == q.tail
+	return q.head.Load() == q.tail.Load()
 }
 
 func (q *mpscQueue[K, V]) tryDequeue(buf []writeCommand[K, V]) int {
 	n := 0
+	pos := q.tail.Load()
 	for n < len(buf) {
-		pos := q.tail
 		cell := &q.buffer[pos&q.mask]
-		seq := cell.seq.Load() // acquire; pairs with the producer's publish
+		seq := cell.seq.Load() // acquire
 		if int64(seq)-int64(pos+1) != 0 {
 			break // not yet published (empty)
 		}
-		q.tail = pos + 1
 		buf[n] = cell.cmd
-		cell.cmd = writeCommand[K, V]{}  // drop references so the GC can reclaim
+		cell.cmd = writeCommand[K, V]{}  // drop references
 		cell.seq.Store(pos + q.mask + 1) // free the slot for the next lap
+		pos++
+		q.tail.Store(pos) // publish progress so quiescent() sees it
 		n++
 	}
 	if n > 0 {

--- a/queue.go
+++ b/queue.go
@@ -11,6 +11,7 @@ const cacheLinePadding = 64
 type writeQueue[K comparable, V any] interface {
 	enqueue(cmd writeCommand[K, V]) error
 	tryDequeue(buf []writeCommand[K, V]) int
+	quiescent() bool
 }
 
 func newWriteQueue[K comparable, V any](size int, wake chan struct{}, closeCh <-chan struct{}) writeQueue[K, V] {
@@ -92,6 +93,17 @@ func (q *mpscQueue[K, V]) enqueue(cmd writeCommand[K, V]) error {
 			// another producer advanced head; retry with a fresh position.
 		}
 	}
+}
+
+// quiescent reports whether the queue holds no in-flight writes. head == tail
+// means every reserved slot has been consumed, so there is neither a published
+// command waiting nor a slot a producer has reserved (advanced head) but not yet
+// published. It is a single-consumer check: the caller must hold the shard drain
+// token so tail is stable. A producer may reserve a slot right after this returns;
+// that write then drains after any inline apply the caller performs, preserving
+// accept order.
+func (q *mpscQueue[K, V]) quiescent() bool {
+	return q.head.Load() == q.tail
 }
 
 func (q *mpscQueue[K, V]) tryDequeue(buf []writeCommand[K, V]) int {

--- a/queue_test.go
+++ b/queue_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func drainAll(q writeQueue[int, int], buf []writeCommand[int, int]) []writeCommand[int, int] {
+func drainAll(q *mpscQueue[int, int], buf []writeCommand[int, int]) []writeCommand[int, int] {
 	var out []writeCommand[int, int]
 	for {
 		n := q.tryDequeue(buf)
@@ -41,7 +41,7 @@ func TestMPSCQueueMinimumRingSize(t *testing.T) {
 func TestMPSCQueueFIFOSingleProducer(t *testing.T) {
 	q := newMPSCQueue[int, int](8, make(chan struct{}, 1), make(chan struct{}))
 	buf := make([]writeCommand[int, int], 3) // small batch to exercise multi-pass drain
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		if err := q.enqueue(writeCommand[int, int]{hash: uint64(i)}); err != nil {
 			t.Fatal(err)
 		}
@@ -60,7 +60,7 @@ func TestMPSCQueueFIFOSingleProducer(t *testing.T) {
 func TestMPSCQueueBackpressureBlocksUntilDrain(t *testing.T) {
 	q := newMPSCQueue[int, int](2, make(chan struct{}, 1), make(chan struct{}))
 	// Fill the ring (2 slots).
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if err := q.enqueue(writeCommand[int, int]{hash: uint64(i)}); err != nil {
 			t.Fatal(err)
 		}
@@ -92,7 +92,7 @@ func TestMPSCQueueBackpressureBlocksUntilDrain(t *testing.T) {
 func TestMPSCQueueCloseWakesBlockedProducer(t *testing.T) {
 	closeCh := make(chan struct{})
 	q := newMPSCQueue[int, int](2, make(chan struct{}, 1), closeCh)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if err := q.enqueue(writeCommand[int, int]{hash: uint64(i)}); err != nil {
 			t.Fatal(err)
 		}
@@ -118,9 +118,6 @@ func TestMPSCQueueCloseWakesBlockedProducer(t *testing.T) {
 	}
 }
 
-// TestMPSCQueueConcurrentProducersNoLoss runs many producers against one
-// draining consumer with back-pressure and verifies every command is delivered
-// exactly once, with per-producer FIFO preserved.
 func TestMPSCQueueConcurrentProducersNoLoss(t *testing.T) {
 	const producers = 8
 	const perProducer = 5000
@@ -153,11 +150,11 @@ func TestMPSCQueueConcurrentProducersNoLoss(t *testing.T) {
 	}()
 
 	var wg sync.WaitGroup
-	for p := 0; p < producers; p++ {
+	for p := range producers {
 		wg.Add(1)
 		go func(p int) {
 			defer wg.Done()
-			for s := 0; s < perProducer; s++ {
+			for s := range perProducer {
 				cmd := writeCommand[int, int]{hash: uint64(p)<<32 | uint64(s)}
 				if err := q.enqueue(cmd); err != nil {
 					t.Errorf("producer %d enqueue: %v", p, err)
@@ -178,26 +175,15 @@ func TestMPSCQueueConcurrentProducersNoLoss(t *testing.T) {
 	}
 }
 
-// TestWriteQueueWakeSignaled confirms enqueue pings the shared wake channel so
-// the worker is told there is work.
 func TestWriteQueueWakeSignaled(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		make func(wake chan struct{}) writeQueue[int, int]
-	}{
-		{"mpsc", func(w chan struct{}) writeQueue[int, int] { return newMPSCQueue[int, int](8, w, make(chan struct{})) }},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			wake := make(chan struct{}, 1)
-			q := tc.make(wake)
-			if err := q.enqueue(writeCommand[int, int]{hash: 1}); err != nil {
-				t.Fatal(err)
-			}
-			select {
-			case <-wake:
-			default:
-				t.Fatal("enqueue did not signal the wake channel")
-			}
-		})
+	wake := make(chan struct{}, 1)
+	q := newMPSCQueue[int, int](8, wake, make(chan struct{}))
+	if err := q.enqueue(writeCommand[int, int]{hash: 1}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-wake:
+	default:
+		t.Fatal("enqueue did not signal the wake channel")
 	}
 }

--- a/read_buffer.go
+++ b/read_buffer.go
@@ -38,8 +38,6 @@ type readBuffer struct {
 	mask    uint64
 }
 
-// newReadBuffer sizes the stripe set to GOMAXPROCS (capped)
-// rounded to a 2^n for mask-based indexing.
 func newReadBuffer() readBuffer {
 	n := max(nextPowerOf2(min(runtime.GOMAXPROCS(0), maxReadStripes)), 1)
 	return readBuffer{

--- a/read_buffer_test.go
+++ b/read_buffer_test.go
@@ -7,17 +7,14 @@ import (
 	"time"
 )
 
-// newReadTestShard builds a minimal SieveTinyLFU shard wired with a read buffer,
-// without spinning up the cache's worker goroutine, so drains are deterministic.
 func newReadTestShard(t *testing.T, cap int64) *shard[int, int] {
 	t.Helper()
 	s := &shard[int, int]{
-		data: make(map[int]*cacheItem[int, int]),
+		tab:  newHtable[int, int](int(cap)),
 		cap:  cap,
 		wake: make(chan struct{}, 1),
 	}
-	s.initLRU()
-	s.sieve = newSieveTinyLFU[int, int](cap, 10, 100)
+	s.sieve = newSieveTinyLFU[int, int](cap, 0, 10, 100)
 	s.readBuf = newReadBuffer()
 	return s
 }
@@ -30,8 +27,8 @@ func TestReadBufferSampleThenDrainFeedsSketch(t *testing.T) {
 		t.Fatalf("initial estimate=%d, want 0", got)
 	}
 
-	for i := 0; i < 50; i++ {
-		s.sampleRead(h, false)
+	for range 50 {
+		s.readBuf.sample(h)
 	}
 	s.drainReadSamples()
 
@@ -56,8 +53,8 @@ func TestReadBufferLossyOverflowDrainsRecentWindow(t *testing.T) {
 	// Push far more than total ring capacity; producers overwrite older slots.
 	// The drain must stay bounded and still replay the most recent window.
 	total := readStripeSlots * (len(s.readBuf.stripes) + 4) * 8
-	for i := 0; i < total; i++ {
-		s.sampleRead(h, false)
+	for range total {
+		s.readBuf.sample(h)
 	}
 	s.drainReadSamples()
 
@@ -72,8 +69,8 @@ func TestReadBufferZeroHashMappedToSentinel(t *testing.T) {
 	s := newReadTestShard(t, 64)
 	// hash 0 collides with the empty-slot sentinel; sample() remaps it to 1 so
 	// it is not silently dropped by the drain.
-	for i := 0; i < 30; i++ {
-		s.sampleRead(0, false)
+	for range 30 {
+		s.readBuf.sample(0)
 	}
 	s.drainReadSamples()
 	if got := s.sieve.estimate(1); got == 0 {
@@ -90,7 +87,7 @@ func TestReadBufferSignalsAtHeadRelativeFullWindow(t *testing.T) {
 	st.tail.Store(10)
 	st.head.Store(10)
 
-	for i := 0; i < readStripeSlots-1; i++ {
+	for i := range readStripeSlots - 1 {
 		_, needDrain := rb.sample(uint64(i + 1))
 		if needDrain {
 			t.Fatalf("sample %d signaled before head-relative window was full", i)
@@ -106,20 +103,18 @@ func TestReadBufferSignalsAtHeadRelativeFullWindow(t *testing.T) {
 	}
 }
 
-// TestReadBufferConcurrentSampleDrain stresses many producers against a single
-// draining consumer; correctness here is "no race / no panic / bounded work".
 func TestReadBufferConcurrentSampleDrain(t *testing.T) {
 	s := newReadTestShard(t, 256)
 
 	var stop atomic.Bool
 	var wg sync.WaitGroup
-	for g := 0; g < 8; g++ {
+	for g := range 8 {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 			h := uint64(id + 1)
 			for !stop.Load() {
-				s.sampleRead(h, false)
+				s.readBuf.sample(h)
 			}
 		}(g)
 	}
@@ -139,11 +134,6 @@ func TestReadBufferConcurrentSampleDrain(t *testing.T) {
 	}
 }
 
-// End-to-end: many read hits on a live cache must not break the read→worker
-// pipeline (Get -> sampleRead -> worker drain). We deliberately do not read the
-// sketch from the test goroutine: the worker mutates it lock-free, so any
-// external read would race. The deterministic sample->drain->sketch assertion
-// lives in TestReadBufferSampleThenDrainFeedsSketch.
 func TestReadHitsDrainWithoutBreakingCache(t *testing.T) {
 	c := newTestCache[int, int](t, Config{
 		MaxSize:         64,
@@ -161,7 +151,7 @@ func TestReadHitsDrainWithoutBreakingCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		if v, ok := c.Get(key); !ok || v != key {
 			t.Fatalf("read %d: got (%d,%v), want (%d,true)", i, v, ok, key)
 		}
@@ -187,7 +177,7 @@ func TestReadMissesFeedAdmissionSketch(t *testing.T) {
 	})
 	defer c.Close()
 
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		if err := c.Set(i, i, time.Hour); err != nil {
 			t.Fatal(err)
 		}
@@ -195,7 +185,7 @@ func TestReadMissesFeedAdmissionSketch(t *testing.T) {
 
 	const key = 10_000
 	h := c.hasher.Sum(key)
-	for i := 0; i < readStripeSlots; i++ {
+	for range readStripeSlots {
 		if _, ok := c.Get(key); ok {
 			t.Fatal("unexpected hit for miss-sampling key")
 		}

--- a/shard.go
+++ b/shard.go
@@ -6,9 +6,10 @@ import (
 )
 
 type shard[K comparable, V any] struct {
-	mu   sync.RWMutex
-	data map[K]*cacheItem[K, V]
-	cap  int64 // resident item limit for this shard; 0 => unlimited
+	mu      sync.RWMutex
+	data    map[K]*cacheItem[K, V]
+	cap     int64 // resident item limit for this shard; 0 => unlimited
+	costCap int64 // same
 
 	queue writeQueue[K, V] // async mutation transport consumed by this shard's worker
 
@@ -16,7 +17,7 @@ type shard[K comparable, V any] struct {
 	// write and read sampling pings it when a stripe fills. Buffered size 1.
 	wake chan struct{}
 
-	// keeps the MPSC queue single-consumer while allowing synchronous
+	// keeps the MPSC queue single consumer while allowing synchronous
 	// callers to help drain their own shard instead of always waiting for the
 	// background worker to run.
 	drainMu    sync.Mutex
@@ -35,6 +36,7 @@ type shard[K comparable, V any] struct {
 	lfuList *lfuList[K, V] // Allocated only for pure LFU policy.
 
 	size        int64 // live items
+	cost        int64 // live item cost
 	hits        int64 // per-shard hits
 	misses      int64 // per-shard misses
 	evictions   int64 // per-shard evictions
@@ -104,6 +106,9 @@ func (s *shard[K, V]) dropItem(
 		s.removePending.Store(true)
 		signal(s.removeWake)
 	}
+	if item.cost != 0 {
+		atomic.AddInt64(&s.cost, -item.cost)
+	}
 	releaseCacheItem(itemPool, item)
 	atomic.AddInt64(&s.size, -1)
 	if statsEnabled && reason == RemovedCapacity {
@@ -133,10 +138,10 @@ func (s *shard[K, V]) ownsItem(item *cacheItem[K, V]) bool {
 	return ok && s.data[key] == item
 }
 
-// belowSieveWarmupLocked reports the initial fill phase for bounded
-// SieveTinyLFU shards. During warmup admission is unconditional so the cache can
-// seed resident state before the frequency sketch starts rejecting candidates.
-func (s *shard[K, V]) belowSieveWarmupLocked() bool {
+// belowSieveWarmup reports the initial fill phase for bounded SieveTinyLFU
+// shards. During warmup admission is unconditional so the cache can seed resident
+// state before the frequency sketch starts rejecting candidates.
+func (s *shard[K, V]) belowSieveWarmup() bool {
 	return s.cap > 0 && s.size*2 < s.cap
 }
 
@@ -146,10 +151,6 @@ func (s *shard[K, V]) belowSieveWarmupLocked() bool {
 // can claim the single consumer token without blocking, bounding inline work to
 // a single stripe; otherwise it wakes the worker. Below that backlog this is
 // just the buffer append.
-//
-// drainInline must be false when the caller holds s.mu: the synchronous write
-// path locks drainMu before s.mu, so draining under s.mu would invert that
-// order and it would also extend an exclusive hold with sketch work. The
 func (s *shard[K, V]) sampleRead(h uint64, drainInline bool) {
 	if s.wake == nil {
 		return
@@ -272,6 +273,9 @@ func (s *shard[K, V]) cleanup(now int64, evictionPolicy EvictionPolicy, itemPool
 				s.sieve.remove(item)
 			default:
 				s.removeFromLRU(item)
+			}
+			if item.cost != 0 {
+				atomic.AddInt64(&s.cost, -item.cost)
 			}
 			releaseCacheItem(itemPool, item)
 			atomic.AddInt64(&s.size, -1)

--- a/shard.go
+++ b/shard.go
@@ -6,12 +6,13 @@ import (
 )
 
 type shard[K comparable, V any] struct {
-	mu      sync.RWMutex
-	data    map[K]*cacheItem[K, V]
-	cap     int64 // resident item limit for this shard; 0 => unlimited
-	costCap int64 // same
+	mu      sync.RWMutex // serializes writers (and cold scans); reads of tab are lock-free
+	tab     *htable[K, V]
+	stats   *stats // shared per-P telemetry
+	cap     int64  // resident item limit for this shard; 0 => unlimited
+	costCap int64  // same
 
-	queue writeQueue[K, V] // async mutation transport consumed by this shard's worker
+	queue *mpscQueue[K, V] // async mutation transport consumed by this shard's worker
 
 	// worker's wake-up: producers ping it after enqueuing a
 	// write and read sampling pings it when a stripe fills. Buffered size 1.
@@ -33,14 +34,10 @@ type shard[K comparable, V any] struct {
 	head *cacheItem[K, V]
 	tail *cacheItem[K, V]
 
-	lfuList *lfuList[K, V] // Allocated only for pure LFU policy.
+	lfuList *lfuList[K, V] // allocated only for pure LFU policy.
 
-	size        int64 // live items
-	cost        int64 // live item cost
-	hits        int64 // per-shard hits
-	misses      int64 // per-shard misses
-	evictions   int64 // per-shard evictions
-	expirations int64 // per-shard TTL expirations
+	size int64 // live items
+	cost int64 // live item cost
 
 	sieve *sieveTinyLFU[K, V]
 
@@ -66,22 +63,28 @@ const (
 	dropSieve
 )
 
-// dropItem removes a resident item from data, unlinks its policy metadata, and
-// returns the cacheItem to the pool. The data check rejects stale queue or hand
-// pointers that may still reference an item after another path already removed
-// or replaced it.
+// dropItem removes a resident item from the table and unlinks its policy
+// metadata. removeExact both rejects stale queue or hand pointers (it only
+// removes when the slot still holds exactly this item) and frees the slot in a
+// single probe, so the downstream unlinks always operate on a confirmed resident.
+// The item itself is not recycled: a lock-free reader may still hold it, so the
+// GC reclaims it.
 func (s *shard[K, V]) dropItem(
 	item *cacheItem[K, V],
-	itemPool *sync.Pool,
 	statsEnabled bool,
 	reason RemovalReason,
 	mode itemDropMode,
 ) bool {
-	key, ok := s.itemKey(item)
-	if !ok {
+	if item == nil {
 		return false
 	}
-	if s.data[key] != item {
+	// an unpublished SieveTinyLFU candidate is live in the policy queues but was
+	// never stored, so it has no table slot to reclaim; unlink policy-only. Every
+	// other item is a confirmed resident and removeExact both rejects stale
+	// queue/hand pointers and frees the slot.
+	if item.unpublished {
+		item.unpublished = false
+	} else if !s.tab.removeExact(item) {
 		return false
 	}
 
@@ -91,9 +94,7 @@ func (s *shard[K, V]) dropItem(
 		s.removeFromLRU(item)
 	case dropSieve:
 		if s.sieve != nil {
-			if !s.sieve.remove(item) {
-				return false
-			}
+			s.sieve.remove(item)
 		} else {
 			s.removeFromLRU(item)
 		}
@@ -101,18 +102,16 @@ func (s *shard[K, V]) dropItem(
 		s.removeFromLRU(item)
 	}
 
-	delete(s.data, key)
-	if s.stageRemoval(key, item.value, reason) {
+	if s.stageRemoval(item.key, item.value, reason) {
 		s.removePending.Store(true)
 		signal(s.removeWake)
 	}
 	if item.cost != 0 {
 		atomic.AddInt64(&s.cost, -item.cost)
 	}
-	releaseCacheItem(itemPool, item)
 	atomic.AddInt64(&s.size, -1)
 	if statsEnabled && reason == RemovedCapacity {
-		atomic.AddInt64(&s.evictions, 1)
+		s.stats.recordEviction()
 	}
 	return true
 }
@@ -125,33 +124,19 @@ func (s *shard[K, V]) stageRemoval(key K, value V, reason RemovalReason) bool {
 	return true
 }
 
-func (s *shard[K, V]) itemKey(item *cacheItem[K, V]) (K, bool) {
-	if item == nil {
-		var zero K
-		return zero, false
-	}
-	return item.key, true
-}
-
-func (s *shard[K, V]) ownsItem(item *cacheItem[K, V]) bool {
-	key, ok := s.itemKey(item)
-	return ok && s.data[key] == item
-}
-
 // belowSieveWarmup reports the initial fill phase for bounded SieveTinyLFU
 // shards. During warmup admission is unconditional so the cache can seed resident
 // state before the frequency sketch starts rejecting candidates.
 func (s *shard[K, V]) belowSieveWarmup() bool {
-	return s.cap > 0 && s.size*2 < s.cap
+	return s.cap > 0 && atomic.LoadInt64(&s.size)*2 < s.cap
 }
 
 // sampleRead records a read access into the per-shard read buffer. sample()
-// reports backlog when the consumer has fallen a full window behind. When that
-// happens and drainInline is set, the reader drains that one stripe itself if it
-// can claim the single consumer token without blocking, bounding inline work to
-// a single stripe; otherwise it wakes the worker. Below that backlog this is
-// just the buffer append.
-func (s *shard[K, V]) sampleRead(h uint64, drainInline bool) {
+// reports backlog when the consumer has fallen a full window behind; the reader
+// then drains that one stripe itself if it can claim the single-consumer token
+// without blocking (bounding inline work to a single stripe), otherwise it wakes
+// the worker. Below that backlog this is just the buffer append.
+func (s *shard[K, V]) sampleRead(h uint64) {
 	if s.wake == nil {
 		return
 	}
@@ -159,7 +144,7 @@ func (s *shard[K, V]) sampleRead(h uint64, drainInline bool) {
 	if !needDrain {
 		return
 	}
-	if drainInline && s.sieve != nil && s.drainMu.TryLock() {
+	if s.sieve != nil && s.drainMu.TryLock() {
 		s.drainStripe(s.sieve, &s.readBuf.stripes[stripe])
 		s.drainMu.Unlock()
 		return
@@ -168,8 +153,7 @@ func (s *shard[K, V]) sampleRead(h uint64, drainInline bool) {
 }
 
 // drainReadSamples replays every stripe's buffered read fingerprints into the
-// frequency sketch. Queue drains are serialized by drainMu so policy maintenance
-// remains single consumer even when synchronous callers help drain their shard.
+// frequency sketch.
 func (s *shard[K, V]) drainReadSamples() {
 	p := s.sieve
 	if p == nil {
@@ -180,9 +164,9 @@ func (s *shard[K, V]) drainReadSamples() {
 	}
 }
 
-// drainStripe replays one stripe's fingerprints into the sketch. The caller must
-// hold drainMu (the single consumer token). When producers have lapped the
-// consumer only the most recent window survives; older samples are dropped.
+// drainStripe replays one stripe's fingerprints into the sketch.
+// When producers have lapped the consumer only the most recent window survives.
+// Older samples are dropped.
 func (s *shard[K, V]) drainStripe(p *sieveTinyLFU[K, V], st *readStripe) {
 	t := st.tail.Load()
 	h := st.head.Load()
@@ -245,43 +229,43 @@ func (s *shard[K, V]) moveToLRUHead(item *cacheItem[K, V]) {
 }
 
 // cleanup expires items under the shard lock and mirrors the same policy unlink
-// rules used by normal deletion. It gathers keys first so the scan phase stays
-// separate from unlinking and item pooling.
-func (s *shard[K, V]) cleanup(now int64, evictionPolicy EvictionPolicy, itemPool *sync.Pool, statsEnabled bool) {
+// rules used by normal deletion. It collects the expired items first so the scan
+// phase stays separate from unlinking and removal.
+func (s *shard[K, V]) cleanup(now int64, evictionPolicy EvictionPolicy, statsEnabled bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var keysToDelete []K
-	for key, item := range s.data {
+	var expired []*cacheItem[K, V]
+	s.tab.forEach(func(item *cacheItem[K, V]) bool {
 		if item.expireTime > 0 && now > item.expireTime {
-			keysToDelete = append(keysToDelete, key)
+			expired = append(expired, item)
 		}
-	}
+		return true
+	})
 
 	staged := false
-	for _, key := range keysToDelete {
-		if item, exists := s.data[key]; exists {
-			delete(s.data, key)
-			if s.stageRemoval(key, item.value, RemovedExpired) {
-				staged = true
-			}
-			switch {
-			case evictionPolicy == LFU:
-				s.lfuList.remove(item)
-				s.removeFromLRU(item)
-			case evictionPolicy == SieveTinyLFU && s.sieve != nil:
-				s.sieve.remove(item)
-			default:
-				s.removeFromLRU(item)
-			}
-			if item.cost != 0 {
-				atomic.AddInt64(&s.cost, -item.cost)
-			}
-			releaseCacheItem(itemPool, item)
-			atomic.AddInt64(&s.size, -1)
-			if statsEnabled {
-				atomic.AddInt64(&s.expirations, 1)
-			}
+	for _, item := range expired {
+		if !s.tab.removeExact(item) {
+			continue
+		}
+		if s.stageRemoval(item.key, item.value, RemovedExpired) {
+			staged = true
+		}
+		switch {
+		case evictionPolicy == LFU:
+			s.lfuList.remove(item)
+			s.removeFromLRU(item)
+		case evictionPolicy == SieveTinyLFU && s.sieve != nil:
+			s.sieve.remove(item)
+		default:
+			s.removeFromLRU(item)
+		}
+		if item.cost != 0 {
+			atomic.AddInt64(&s.cost, -item.cost)
+		}
+		atomic.AddInt64(&s.size, -1)
+		if statsEnabled {
+			s.stats.recordExpiration()
 		}
 	}
 

--- a/sieve.go
+++ b/sieve.go
@@ -1,9 +1,6 @@
 package kioshun
 
-import (
-	"sync"
-	"sync/atomic"
-)
+import "sync/atomic"
 
 const (
 	defaultProbationRatio = 1
@@ -24,18 +21,19 @@ const (
 	probationResurrectLow = 0.10
 
 	// probationGrowStepPct is how much of total capacity the probation window
-	// grows per maintenance window when a shifting hot set is detected. Larger
-	// than adaptStep (1%) so the window reaches a useful size within the short
-	// adaptation budget a shifting workload allows.
+	// grows per maintenance window when a shifting hot set is detected.
 	probationGrowStepPct = 10
 )
 
-// sieveQueueID mirrors queue ownership on cacheItem for cheap state inspection.
-// the authoritative ownership pointer is cacheItem.sieveQ.
+// sieveQueueID is the authoritative SIEVE queue ownership tag stored on each
+// cacheItem. It replaces an 8-byte owning-queue pointer with a single byte;
+// queueNone (the zero value, so a freshly allocated item starts unlinked) means
+// the item is in neither queue.
 type sieveQueueID uint8
 
 const (
-	probationQueue sieveQueueID = iota
+	queueNone sieveQueueID = iota
+	probationQueue
 	mainQueue
 )
 
@@ -59,20 +57,27 @@ func clearSieveItemVisited[K comparable, V any](it *cacheItem[K, V]) {
 	}
 }
 
-// sieveQueue is an FIFO queue backed by cacheItem links.
+// sieveQueue is a FIFO queue backed by cacheItem links. (id, owner) is the
+// queue's instance identity - the role (probation/main) and the owning shard -
+// stamped onto every item it links so holds/remove recognize membership of this
+// exact queue from the item's two one-byte tags instead of a back-pointer.
 type sieveQueue[K comparable, V any] struct {
-	head cacheItem[K, V]
-	tail cacheItem[K, V]
-	size int64
+	head  cacheItem[K, V]
+	tail  cacheItem[K, V]
+	size  int64
+	id    sieveQueueID
+	owner uint8 // shard index that owns this queue instance
 }
 
-func (q *sieveQueue[K, V]) init() {
+func (q *sieveQueue[K, V]) init(id sieveQueueID, owner uint8) {
+	q.id = id
+	q.owner = owner
 	q.head.prev = nil
 	q.head.next = &q.tail
-	q.head.sieveQ = nil
+	q.head.queue = queueNone
 	q.tail.prev = &q.head
 	q.tail.next = nil
-	q.tail.sieveQ = nil
+	q.tail.queue = queueNone
 	q.size = 0
 }
 
@@ -81,23 +86,18 @@ func (q *sieveQueue[K, V]) pushFront(it *cacheItem[K, V]) {
 	q.head.next = it
 	it.prev = &q.head
 	it.next = n
-	it.sieveQ = q
+	it.queue = q.id
+	it.queueOwner = q.owner
 	n.prev = it
 	q.size++
 }
 
-func (q *sieveQueue[K, V]) popBack() *cacheItem[K, V] {
-	if q.empty() {
-		return nil
-	}
-
-	it := q.tail.prev
-	q.remove(it)
-	return it
+func (q *sieveQueue[K, V]) ownsTag(it *cacheItem[K, V]) bool {
+	return it != nil && it.queue == q.id && it.queueOwner == q.owner
 }
 
 func (q *sieveQueue[K, V]) remove(it *cacheItem[K, V]) bool {
-	if it == nil || it.sieveQ != q || it.prev == nil || it.next == nil {
+	if !q.ownsTag(it) || it.prev == nil || it.next == nil {
 		return false
 	}
 	if it.prev.next != it || it.next.prev != it {
@@ -108,7 +108,7 @@ func (q *sieveQueue[K, V]) remove(it *cacheItem[K, V]) bool {
 	it.next.prev = it.prev
 	it.prev = nil
 	it.next = nil
-	it.sieveQ = nil
+	it.queue = queueNone
 	if q.size > 0 {
 		q.size--
 	}
@@ -123,12 +123,8 @@ func (q *sieveQueue[K, V]) isSentinel(it *cacheItem[K, V]) bool {
 	return it == &q.head || it == &q.tail
 }
 
-// holds reports whether it is a live, non-sentinel node currently linked into q.
-// remove clears sieveQ on eviction and the head/tail guards never carry a queue
-// pointer so this one check subsumes the nil/guard/ownership tests the policy
-// would otherwise spell out at each call site.
 func (q *sieveQueue[K, V]) holds(it *cacheItem[K, V]) bool {
-	return it != nil && it.sieveQ == q && it != &q.head && it != &q.tail
+	return q.ownsTag(it) && it != &q.head && it != &q.tail
 }
 
 // adaptiveController accumulates the per-cycle signals that drive probation/main
@@ -138,7 +134,7 @@ func (q *sieveQueue[K, V]) holds(it *cacheItem[K, V]) bool {
 //
 // mainSurvivals counts main queue residents the SIEVE hand spared during
 // eviction sweeps (a set visited bit buys a second chance). It is the
-// maintenance path proxy for "the main cache is earning its capacity" annd
+// maintenance path proxy for "the main cache is earning its capacity" and
 // replaces a per-read main hit counter whose increment contended on the
 // read hot path. Counting survivors instead of raw hits also tracks how many
 // distinct main items reads keep alive, rather than being skewed by a single
@@ -161,7 +157,7 @@ type adaptiveController struct {
 	// this cycle; cycleB2Hits counts inserts whose key was a recent main victim
 	// (a resurrection). The rate cycleB2Hits/cycleMainEvicts is high
 	// on loops (we keep evicting items we still need) and near zero on
-	// shifting/bursty/zipf workloads which is what the addmision tuner keys on.
+	// shifting/bursty/zipf workloads which is what the admission tuner keys on.
 	cycleMainEvicts uint64
 	cycleB2Hits     uint64
 }
@@ -280,20 +276,21 @@ type sieveTinyLFU[K comparable, V any] struct {
 	maxProbationCap int64
 	adaptStep       int64
 	costAdmission   CostAdmission
+	owner           uint8 // shard index stamped onto this shard's queue instances
 }
 
 // newSieveTinyLFU builds the per-shard admission state for a bounded shard.
 // Probation is clamped between 1% and 60% of capacity so main has room for
 // protected entries when capacity permits, while the ghost queue is sized as a
 // fraction of main.
-func newSieveTinyLFU[K comparable, V any](c int64, pr, gr uint8, modes ...CostAdmission) *sieveTinyLFU[K, V] {
+func newSieveTinyLFU[K comparable, V any](c int64, owner uint8, pr, gr uint8, modes ...CostAdmission) *sieveTinyLFU[K, V] {
 	mode := CostAdmissionFrequency
 	if len(modes) > 0 {
 		mode = modes[0]
 	}
-	p := &sieveTinyLFU[K, V]{capacity: c, costAdmission: mode}
-	p.probation.init()
-	p.main.init()
+	p := &sieveTinyLFU[K, V]{capacity: c, costAdmission: mode, owner: owner}
+	p.probation.init(probationQueue, owner)
+	p.main.init(mainQueue, owner)
 
 	if pr == 0 {
 		pr = defaultProbationRatio
@@ -368,29 +365,28 @@ func (p *sieveTinyLFU[K, V]) owns(it *cacheItem[K, V]) bool {
 }
 
 func (p *sieveTinyLFU[K, V]) recordReadHit(it *cacheItem[K, V]) {
-	// Reads only set the visited bit; queue ownership is maintained by the write.
-	// markSieveItemVisited is a conditional atomic store (skipped once the bit is
-	// set), so a hot item costs at most one shared-state load here. The adaptive
-	// controller's "main is useful" signal is gathered on the maintenance path
-	// (see findMainVictim), so the read path stays free of contended writes.
-	if p.owns(it) {
-		markSieveItemVisited(it)
-	}
+	// reads only set the visited bit. markSieveItemVisited is a conditional atomic
+	// store (skipped once the bit is set) so a hot item costs at most one
+	// shared-state load here. The read is lock-free, so it must not inspect queue
+	// ownership (it.queue is writer-only and would race the maintenance path); a
+	// resident table hit is in a SIEVE queue by construction, and setting the bit
+	// on an item the writer is concurrently moving or evicting is harmless. The
+	// adaptive controller's "main is useful" signal is gathered on the maintenance
+	// path (see findMainVictim), so the read path stays free of contended writes.
+	markSieveItemVisited(it)
 }
 
 // recordUpdate handles Set on an existing resident. Updates are treated as
 // reuse signals: main entries get another SIEVE chance, while probation entries
 // can be promoted before they reach the probation tail.
 func (p *sieveTinyLFU[K, V]) recordUpdate(it *cacheItem[K, V]) {
-	switch it.sieveQ {
-	case &p.main:
-		it.queue = mainQueue
+	switch it.queue {
+	case mainQueue:
 		markSieveItemVisited(it)
 		if it.reuse < maxItemReuse {
 			it.reuse++
 		}
-	case &p.probation:
-		it.queue = probationQueue
+	case probationQueue:
 		wasVisited := sieveItemVisited(it)
 		if it.reuse < maxItemReuse {
 			it.reuse++
@@ -407,9 +403,6 @@ func (p *sieveTinyLFU[K, V]) recordUpdate(it *cacheItem[K, V]) {
 // already shown that the item was evicted too soon; ghost hits bypass probation
 // and enter main as protected entries.
 func (p *sieveTinyLFU[K, V]) insert(it *cacheItem[K, V], gh bool) {
-	// A key that was a recent main eviction victim is "resurrecting": the cache
-	// evicted it too soon. The admission tuner counts resurrections to detect a
-	// loop-like workload (see tuneAdmission); placement itself is unchanged.
 	if p.mghost.contains(it.hash) {
 		p.mghost.remove(it.hash)
 		p.controller.cycleB2Hits++
@@ -448,13 +441,13 @@ func (p *sieveTinyLFU[K, V]) remove(it *cacheItem[K, V]) bool {
 	}
 
 	removed := false
-	switch it.sieveQ {
-	case &p.main:
+	switch it.queue {
+	case mainQueue:
 		if p.hand == it {
 			p.hand = p.previousMainItem(it)
 		}
 		removed = p.main.remove(it)
-	case &p.probation:
+	case probationQueue:
 		removed = p.probation.remove(it)
 	default:
 		if p.hand == it {
@@ -465,16 +458,15 @@ func (p *sieveTinyLFU[K, V]) remove(it *cacheItem[K, V]) bool {
 		return false
 	}
 
-	it.queue = probationQueue
-	it.sieveQ = nil
+	// queue was reset to queueNone by the queue's remove; just clear recency.
 	it.reuse = 0
 	clearSieveItemVisited(it)
 	return true
 }
 
 func (p *sieveTinyLFU[K, V]) reset() {
-	p.probation.init()
-	p.main.init()
+	p.probation.init(probationQueue, p.owner)
+	p.main.init(mainQueue, p.owner)
 	p.ghost.clear()
 	p.mghost.clear()
 	p.sketch.clear()
@@ -486,7 +478,7 @@ func (p *sieveTinyLFU[K, V]) reset() {
 }
 
 func (p *sieveTinyLFU[K, V]) promote(it *cacheItem[K, V]) {
-	if it == nil || it.sieveQ != &p.probation || p.mainCap <= 0 {
+	if it == nil || it.queue != probationQueue || p.mainCap <= 0 {
 		return
 	}
 
@@ -496,12 +488,40 @@ func (p *sieveTinyLFU[K, V]) promote(it *cacheItem[K, V]) {
 	p.stats.Promotions++
 }
 
+// replaceNode swaps a resident's node identity in place: new takes old's exact
+// SIEVE queue position and recency state. A value update allocates a fresh
+// immutable item so lock-free readers never observe a torn value; keeping the
+// new node where the old one sat means the update is not mistaken for a fresh
+// insertion (recency is preserved).
+func (p *sieveTinyLFU[K, V]) replaceNode(old, new *cacheItem[K, V]) {
+	new.queue = old.queue
+	new.queueOwner = old.queueOwner
+	new.reuse = old.reuse
+	new.prev = old.prev
+	new.next = old.next
+	if old.prev != nil {
+		old.prev.next = new
+	}
+	if old.next != nil {
+		old.next.prev = new
+	}
+	if sieveItemVisited(old) {
+		markSieveItemVisited(new)
+	}
+	if p.hand == old {
+		p.hand = new
+	}
+	old.prev = nil
+	old.next = nil
+	old.queue = queueNone
+}
+
 // dropProbationVictim records a probation eviction and remembers the key for
 // possible ghost hit readmission.
-func (s *shard[K, V]) dropProbationVictim(it *cacheItem[K, V], pool *sync.Pool, stats bool) bool {
+func (s *shard[K, V]) dropProbationVictim(it *cacheItem[K, V], stats bool) bool {
 	p := s.sieve
 	h := it.hash
-	if !s.dropSieveItem(it, pool, stats, RemovedCapacity) {
+	if !s.dropSieveItem(it, stats, RemovedCapacity) {
 		return false
 	}
 	p.controller.probationEvictions++
@@ -514,7 +534,7 @@ func (s *shard[K, V]) dropProbationVictim(it *cacheItem[K, V], pool *sync.Pool, 
 // evictProbation inspects the oldest probation entry. A recently reused entry
 // is promoted and returned as an in-flight main candidate; a cold entry is
 // evicted and recorded in the ghost queue.
-func (s *shard[K, V]) evictProbation(pool *sync.Pool, stats bool) *cacheItem[K, V] {
+func (s *shard[K, V]) evictProbation(stats bool) *cacheItem[K, V] {
 	p := s.sieve
 	if p.probation.empty() {
 		return nil
@@ -529,7 +549,7 @@ func (s *shard[K, V]) evictProbation(pool *sync.Pool, stats bool) *cacheItem[K, 
 		return it
 	}
 
-	s.dropProbationVictim(it, pool, stats)
+	s.dropProbationVictim(it, stats)
 	return nil
 }
 
@@ -538,7 +558,6 @@ func (s *shard[K, V]) evictProbation(pool *sync.Pool, stats bool) *cacheItem[K, 
 // candidate is not counted as an eviction because the policy rejected the
 // candidate rather than selecting a replacement victim.
 func (s *shard[K, V]) evictMain(
-	pool *sync.Pool,
 	stats bool,
 	in *cacheItem[K, V],
 	tie bool,
@@ -546,7 +565,15 @@ func (s *shard[K, V]) evictMain(
 	force bool,
 ) bool {
 	p := s.sieve
-	if in != nil && (!s.ownsItem(in) || !p.owns(in)) {
+	// policy ownership is the liveness signal for the in-flight candidate, and a
+	// table-identity check would be both redundant and wrong here. At a writer
+	// decision point under s.mu the invariant holds: a published, policy-owned item
+	// is table-resident (eviction resets queue in lockstep with the table removal,
+	// so owns can never outlive the slot), so re-checking the table would only
+	// confirm what owns already implies; while an unpublished insert is
+	// intentionally table-absent until admission, so looking it up would wrongly
+	// reject it.
+	if in != nil && !p.owns(in) {
 		in = nil
 		tie = false
 	}
@@ -555,7 +582,7 @@ func (s *shard[K, V]) evictMain(
 	if v == nil {
 		if force && in != nil {
 			p.controller.cycleRejects++
-			s.dropSieveItem(in, pool, stats, RemovedRejected)
+			s.dropSieveItem(in, stats, RemovedRejected)
 			return true
 		}
 		return false
@@ -563,11 +590,11 @@ func (s *shard[K, V]) evictMain(
 
 	if in != nil && in != v && !p.shouldAdmit(in, v, tie) {
 		p.controller.cycleRejects++
-		return s.dropSieveItem(in, pool, stats, RemovedRejected)
+		return s.dropSieveItem(in, stats, RemovedRejected)
 	}
 
-	vh := v.hash // capture before drop zeroes the item for B2
-	if s.dropSieveItem(v, pool, stats, RemovedCapacity) {
+	vh := v.hash // capture the victim hash for the B2 ghost before it is unlinked
+	if s.dropSieveItem(v, stats, RemovedCapacity) {
 		p.controller.cycleEvictions++
 		p.controller.cycleMainEvicts++
 		p.mghost.add(vh) // record for resurrection detection
@@ -582,16 +609,13 @@ func (s *shard[K, V]) evictMain(
 // forced pass is a last-resort repair so promotions cannot leave the shard over
 // capacity.
 func (s *shard[K, V]) enforceSieveCapacity(
-	pool *sync.Pool,
 	stats bool,
 	in *cacheItem[K, V],
 	tie bool,
 ) {
 	p := s.sieve
-	// evicts the probation tail; a promoted survivor becomes
-	// the in-flight candidate weighed against the next main victim.
 	admitFromProbation := func() {
-		if it := s.evictProbation(pool, stats); it != nil {
+		if it := s.evictProbation(stats); it != nil {
 			in, tie = it, true
 		}
 	}
@@ -605,7 +629,7 @@ func (s *shard[K, V]) enforceSieveCapacity(
 			evictIn, evictTie := in, tie
 
 			inProbation := in != nil &&
-				in.sieveQ == &p.probation &&
+				in.queue == probationQueue &&
 				p.probation.size <= p.probationCap
 
 			// loopish mirrors adaptSize: a cyclic workload is being pinned by, or is
@@ -622,7 +646,7 @@ func (s *shard[K, V]) enforceSieveCapacity(
 					p.controller.resurrectionRate() < probationResurrectLow)
 
 			if shouldKeep {
-				// Probation (the recency admission window) is below target on an
+				// probation (the recency admission window) is below target on an
 				// unweighted, non-loop, frequency-mode shard: keep the new first-touch
 				// resident and make main yield a slot instead of forcing it to beat
 				// stale sketch history before it can prove reuse. Gated off for weighted
@@ -631,7 +655,7 @@ func (s *shard[K, V]) enforceSieveCapacity(
 				// or is pinning a loop, where churning main hurts the resident set.
 				evictIn, evictTie = nil, false
 			}
-			if s.evictMain(pool, stats, evictIn, evictTie, defaultMainVictimScan, false) {
+			if s.evictMain(stats, evictIn, evictTie, defaultMainVictimScan, false) {
 				in, tie = nil, false
 			}
 		case s.overCapacity() && !p.probation.empty():
@@ -653,10 +677,10 @@ func (s *shard[K, V]) enforceSieveCapacity(
 		admitFromProbation()
 	}
 	if (p.main.size > p.mainCap || s.overCapacity()) && !p.main.empty() {
-		s.evictMain(pool, stats, in, tie, defaultMainVictimScan, true)
+		s.evictMain(stats, in, tie, defaultMainVictimScan, true)
 	}
-	for s.overCapacity() && len(s.data) > 0 {
-		if !s.forceDropSieveItem(pool, stats) {
+	for s.overCapacity() && s.tab.length() > 0 {
+		if !s.forceDropSieveItem(stats) {
 			return
 		}
 	}
@@ -1009,21 +1033,21 @@ func (p *sieveTinyLFU[K, V]) setProbationCap(n int64) {
 
 // forceDropSieveItem is the final capacity repair path. It removes the
 // probation tail first, then a forced main victim if probation is empty.
-func (s *shard[K, V]) forceDropSieveItem(pool *sync.Pool, stats bool) bool {
+func (s *shard[K, V]) forceDropSieveItem(stats bool) bool {
 	p := s.sieve
 	if !p.probation.empty() {
 		it := p.probation.tail.prev
 		if !p.probation.holds(it) {
 			return false
 		}
-		return s.dropProbationVictim(it, pool, stats)
+		return s.dropProbationVictim(it, stats)
 	}
 	if !p.main.empty() {
 		it := p.findMainVictim(1, true)
 		if it == nil {
 			return false
 		}
-		if s.dropSieveItem(it, pool, stats, RemovedCapacity) {
+		if s.dropSieveItem(it, stats, RemovedCapacity) {
 			p.controller.cycleEvictions++
 			p.stats.MainEvictions++
 			return true
@@ -1032,6 +1056,6 @@ func (s *shard[K, V]) forceDropSieveItem(pool *sync.Pool, stats bool) bool {
 	return false
 }
 
-func (s *shard[K, V]) dropSieveItem(it *cacheItem[K, V], pool *sync.Pool, stats bool, reason RemovalReason) bool {
-	return s.dropItem(it, pool, stats, reason, dropSieve)
+func (s *shard[K, V]) dropSieveItem(it *cacheItem[K, V], stats bool, reason RemovalReason) bool {
+	return s.dropItem(it, stats, reason, dropSieve)
 }

--- a/sieve.go
+++ b/sieve.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	defaultProbationRatio = 10
+	defaultProbationRatio = 1
 	defaultGhostRatio     = 100
 )
 
@@ -150,7 +150,7 @@ type adaptiveController struct {
 	mainSurvivals       uint64
 	observationsInCycle uint64
 
-	// churn cost for the admission tuner: evictions are residents displaced to
+	// cost for the admission tuner: evictions are residents displaced to
 	// stay in capacity, rejects are admitted candidates dropped again. Their sum
 	// falls when admission keeps a stable working set and rises when it thrashes,
 	// so it is the maintenance path proxy the admission tuner watches.
@@ -215,13 +215,16 @@ const (
 )
 
 const (
-	admissionEntryEvidence = 3.0
-	admissionResurrectHigh = 0.5 // per-cycle resurrection rate that counts as evidence
-	admissionCommitFactor  = 0.9 // trial commits if churn < recency baseline * this
-	admissionRevertFactor  = 1.5 // committed reverts if churn > committed low * this
-	admissionChurnEWMA     = 0.5 // churn baseline smoothing
-	admissionBackoffStart  = 3   // recency cooldown cycles after a reverted trial
-	admissionBackoffMax    = 96  // ceiling on the doubling backoff
+	admissionEntryEvidence  = 1.0
+	admissionResurrectHigh  = 0.5 // per-cycle resurrection rate that counts as evidence
+	admissionCommitFactor   = 0.9 // trial commits if churn < recency baseline * this
+	admissionRevertFactor   = 1.5 // committed reverts if churn > committed low * this
+	admissionChurnEWMA      = 0.5 // churn baseline smoothing
+	admissionBackoffStart   = 3   // recency cooldown cycles after a reverted trial
+	admissionBackoffMax     = 96  // ceiling on the doubling backoff
+	adaptiveCycleMultiplier = 4
+	adaptiveMinCycleCap     = 1024
+	adaptiveMinCycle        = 32768
 )
 
 // admissionTuner self-selects a shard's admissionMode with no configuration. It
@@ -276,14 +279,19 @@ type sieveTinyLFU[K comparable, V any] struct {
 	minProbationCap int64
 	maxProbationCap int64
 	adaptStep       int64
+	costAdmission   CostAdmission
 }
 
 // newSieveTinyLFU builds the per-shard admission state for a bounded shard.
 // Probation is clamped between 1% and 60% of capacity so main has room for
 // protected entries when capacity permits, while the ghost queue is sized as a
 // fraction of main.
-func newSieveTinyLFU[K comparable, V any](c int64, pr, gr uint8) *sieveTinyLFU[K, V] {
-	p := &sieveTinyLFU[K, V]{capacity: c}
+func newSieveTinyLFU[K comparable, V any](c int64, pr, gr uint8, modes ...CostAdmission) *sieveTinyLFU[K, V] {
+	mode := CostAdmissionFrequency
+	if len(modes) > 0 {
+		mode = modes[0]
+	}
+	p := &sieveTinyLFU[K, V]{capacity: c, costAdmission: mode}
 	p.probation.init()
 	p.main.init()
 
@@ -402,13 +410,13 @@ func (p *sieveTinyLFU[K, V]) insert(it *cacheItem[K, V], gh bool) {
 	// A key that was a recent main eviction victim is "resurrecting": the cache
 	// evicted it too soon. The admission tuner counts resurrections to detect a
 	// loop-like workload (see tuneAdmission); placement itself is unchanged.
-	if p.mghost.contains(it.hash, it.tag) {
-		p.mghost.remove(it.hash, it.tag)
+	if p.mghost.contains(it.hash) {
+		p.mghost.remove(it.hash)
 		p.controller.cycleB2Hits++
 	}
 
 	if gh && p.mainCap > 0 {
-		p.ghost.remove(it.hash, it.tag)
+		p.ghost.remove(it.hash)
 		p.controller.ghostHits++
 		p.stats.GhostHits++
 		p.insertMain(it)
@@ -492,14 +500,14 @@ func (p *sieveTinyLFU[K, V]) promote(it *cacheItem[K, V]) {
 // possible ghost hit readmission.
 func (s *shard[K, V]) dropProbationVictim(it *cacheItem[K, V], pool *sync.Pool, stats bool) bool {
 	p := s.sieve
-	h, tag := it.hash, it.tag
+	h := it.hash
 	if !s.dropSieveItem(it, pool, stats, RemovedCapacity) {
 		return false
 	}
 	p.controller.probationEvictions++
 	p.controller.cycleEvictions++
 	p.stats.ProbationEvictions++
-	p.ghost.add(h, tag)
+	p.ghost.add(h)
 	return true
 }
 
@@ -558,11 +566,11 @@ func (s *shard[K, V]) evictMain(
 		return s.dropSieveItem(in, pool, stats, RemovedRejected)
 	}
 
-	vh, vtag := v.hash, v.tag // capture before drop zeroes the item for B2
+	vh := v.hash // capture before drop zeroes the item for B2
 	if s.dropSieveItem(v, pool, stats, RemovedCapacity) {
 		p.controller.cycleEvictions++
 		p.controller.cycleMainEvicts++
-		p.mghost.add(vh, vtag) // record for resurrection detection
+		p.mghost.add(vh) // record for resurrection detection
 		p.stats.MainEvictions++
 		return true
 	}
@@ -618,15 +626,27 @@ func (s *shard[K, V]) enforceSieveCapacity(
 	if (p.main.size > p.mainCap || s.overCapacity()) && !p.main.empty() {
 		s.evictMain(pool, stats, in, tie, defaultMainVictimScan, true)
 	}
-	if s.overCapacity() {
-		s.forceDropSieveItem(pool, stats)
+	for s.overCapacity() && len(s.data) > 0 {
+		if !s.forceDropSieveItem(pool, stats) {
+			return
+		}
 	}
 }
 
 func (s *shard[K, V]) overCapacity() bool {
 	// warm fill to the shard cap; enforce probation/main pressure only after a
 	// new admission would exceed resident capacity.
-	return atomic.LoadInt64(&s.size) > s.cap
+	if s.cap > 0 && atomic.LoadInt64(&s.size) > s.cap {
+		return true
+	}
+	return s.costCap > 0 && atomic.LoadInt64(&s.cost) > s.costCap
+}
+
+func (s *shard[K, V]) wouldOverCapacity(addCost int64) bool {
+	if s.cap > 0 && atomic.LoadInt64(&s.size) >= s.cap {
+		return true
+	}
+	return s.costCap > 0 && atomic.LoadInt64(&s.cost)+addCost > s.costCap
 }
 
 // mainCandidate normalizes a traversal cursor to a live main node: it falls back
@@ -680,12 +700,12 @@ func (p *sieveTinyLFU[K, V]) findMainVictim(scan int64, force bool) *cacheItem[K
 	}
 
 	if force {
-		it, ok := p.mainCandidate(it)
+		cit, ok := p.mainCandidate(it)
 		if !ok {
 			return nil
 		}
-		p.hand = p.previousMainItem(it)
-		return it
+		p.hand = p.previousMainItem(cit)
+		return cit
 	}
 
 	p.hand = it
@@ -717,7 +737,7 @@ func (p *sieveTinyLFU[K, V]) previousMainItem(it *cacheItem[K, V]) *cacheItem[K,
 func (p *sieveTinyLFU[K, V]) shouldAdmit(in, v *cacheItem[K, V], tie bool) bool {
 	if p.tuner.mode == admitFrequency {
 		// plain TinyLFU: incumbent wins ties, pinning a stable set for loops.
-		return p.estimate(in.hash) > p.estimate(v.hash)
+		return p.compareAdmissionScore(in, v) > 0
 	}
 
 	// ghost hit or probation promotion has already proven short-term reuse.
@@ -727,18 +747,92 @@ func (p *sieveTinyLFU[K, V]) shouldAdmit(in, v *cacheItem[K, V], tie bool) bool 
 		return true
 	}
 
-	cf := p.estimate(in.hash)
-	vf := p.estimate(v.hash)
-	if cf > vf {
+	cmp := p.compareAdmissionScore(in, v)
+	if cmp > 0 {
 		return true
 	}
-	if cf < vf {
-		if tie && cf+1 >= vf {
+	if cmp < 0 {
+		if tie && p.closeAdmissionScore(in, v) {
 			return true
 		}
 		return false
 	}
 	return tie || (!sieveItemVisited(v) && v.reuse == 0)
+}
+
+// compareAdmissionScore orders candidate against victim. Frequency mode is a
+// plain frequency comparison and pays no cost overhead. Cost-aware modes weight
+// each frequency by the other item's cost denominator, cross-multiplied to
+// compare the ratios frequency/cost without dividing.
+func (p *sieveTinyLFU[K, V]) compareAdmissionScore(in, v *cacheItem[K, V]) int {
+	cf := uint64(p.estimate(in.hash))
+	vf := uint64(p.estimate(v.hash))
+	if p.costAdmission == CostAdmissionFrequency {
+		return compareUint64(cf, vf)
+	}
+	return compareUint64(mulScore(cf, p.costDenom(v)), mulScore(vf, p.costDenom(in)))
+}
+
+// closeAdmissionScore reports whether the candidate is within one frequency
+// step of the victim, the tie-break used when SIEVE has already proven reuse.
+func (p *sieveTinyLFU[K, V]) closeAdmissionScore(in, v *cacheItem[K, V]) bool {
+	cf := uint64(p.estimate(in.hash))
+	vf := uint64(p.estimate(v.hash))
+	if p.costAdmission == CostAdmissionFrequency {
+		return cf+1 >= vf
+	}
+	return mulScore(cf+1, p.costDenom(v)) >= mulScore(vf, p.costDenom(in))
+}
+
+// costDenom is the admission denominator for an item under a cost-aware mode.
+// It is only reached when costAdmission is not Frequency. Density uses the
+// clamped cost directly; Balanced takes its integer square root and is the only
+// mode that pays a per-comparison square root.
+func (p *sieveTinyLFU[K, V]) costDenom(it *cacheItem[K, V]) uint64 {
+	if p.costAdmission == CostAdmissionBalanced {
+		return isqrt64(scoreCost(it.cost))
+	}
+	return scoreCost(it.cost)
+}
+
+// scoreCost clamps a raw cost to a positive admission weight so a zero- or
+// unit-cost item never zeroes the cross-multiplied comparison.
+func scoreCost(cost int64) uint64 {
+	if cost <= 1 {
+		return 1
+	}
+	return uint64(cost)
+}
+
+func compareUint64(a, b uint64) int {
+	switch {
+	case a > b:
+		return 1
+	case a < b:
+		return -1
+	default:
+		return 0
+	}
+}
+
+func mulScore(a, b uint64) uint64 {
+	if a != 0 && b > ^uint64(0)/a {
+		return ^uint64(0)
+	}
+	return a * b
+}
+
+func isqrt64(n uint64) uint64 {
+	if n <= 1 {
+		return 1
+	}
+	x := n
+	y := (x + 1) >> 1
+	for y < x {
+		x = y
+		y = (x + n/x) >> 1
+	}
+	return x
 }
 
 // tick advances the self-tuning controllers once per window of observations. The
@@ -747,7 +841,10 @@ func (p *sieveTinyLFU[K, V]) shouldAdmit(in, v *cacheItem[K, V], tie bool) bool 
 // so they run together before the cycle resets.
 func (p *sieveTinyLFU[K, V]) tick() {
 	p.controller.observationsInCycle++
-	win := uint64(p.capacity * 10)
+	win := uint64(p.capacity * adaptiveCycleMultiplier)
+	if p.capacity >= adaptiveMinCycleCap {
+		win = max(win, uint64(adaptiveMinCycle))
+	}
 	if win == 0 || p.controller.observationsInCycle < win {
 		return
 	}
@@ -775,13 +872,14 @@ func (p *sieveTinyLFU[K, V]) tick() {
 // frequency - on a small probation.
 //
 // Otherwise it falls back to the original recency heuristic: grow modestly when
-// B1 ghost hits dominate probation evictions (probation too small, the loop grow
-// path included), shrink when probation churns far more than it promotes while
-// main keeps earning its keep (probation too large for a stationary workload).
+// B1 ghost hits dominate probation evictions and the dual-ghost signal says
+// main victims are not resurrecting, shrink when probation churns far more than
+// it promotes while main keeps earning its keep (probation too large for a
+// stationary workload).
 func (p *sieveTinyLFU[K, V]) adaptSize() {
 	c := &p.controller
 	resurrect := c.resurrectionRate()
-	// A cyclic ("loop") workload is identified by the admission tuner accumulating
+	// cyclic ("loop") workload is identified by the admission tuner accumulating
 	// resurrection evidence (or already committed to frequency); while that
 	// signature is present probation stays small so the pinned set holds.
 	loopish := p.tuner.mode == admitFrequency || p.tuner.evidence > 0
@@ -789,13 +887,13 @@ func (p *sieveTinyLFU[K, V]) adaptSize() {
 	switch {
 	case !loopish && c.cycleMainEvicts > c.promotions &&
 		resurrect < probationResurrectLow && c.ghostHits > c.promotions:
-		// Shifting hot set: grow the recency window quickly so newly hot entries
+		// shifting hot set: grow the recency window quickly so newly hot entries
 		// survive to their reuse instead of being evicted from a tiny probation.
 		if p.probationCap < p.maxProbationCap {
 			step := max(int64(1), p.capacity*probationGrowStepPct/100)
 			p.setProbationCap(p.probationCap + step)
 		}
-	case c.ghostHits > c.probationEvictions/4:
+	case !loopish && resurrect < probationResurrectLow && c.ghostHits > c.probationEvictions/4:
 		if p.probationCap < p.maxProbationCap {
 			p.setProbationCap(p.probationCap + p.adaptStep)
 		}
@@ -827,10 +925,10 @@ func (p *sieveTinyLFU[K, V]) tuneAdmission() {
 			t.cooldown--
 			return
 		}
-		// Accumulate resurrection evidence weighted by strength: a pure loop
-		// (resurrection ~1.0) reaches the threshold in ~3 cycles; a workload whose
-		// victims are abandoned (shifting/bursty, resurrection ~0) never does, so it
-		// never trials frequency and never regresses.
+		// accumulate resurrection evidence weighted by strength: a pure loop
+		// (resurrection ~1.0) reaches the threshold in one strong cycle; a workload
+		// whose victims are abandoned (shifting/bursty, resurrection ~0) never does,
+		// so it never trials frequency and never regresses.
 		if resurrect >= admissionResurrectHigh {
 			t.evidence += resurrect
 		} else {
@@ -852,7 +950,7 @@ func (p *sieveTinyLFU[K, V]) tuneAdmission() {
 		}
 
 	case tunerFrequency:
-		// Escape when churn climbs above the pinned low reference (the workload
+		// escape when climbs above the pinned low reference (the workload
 		// shifted out from under the pinned set) or back toward the recency
 		// baseline (frequency stopped helping).
 		if churn > t.lowChurn*admissionRevertFactor || churn > t.baseChurn*admissionCommitFactor {

--- a/sieve.go
+++ b/sieve.go
@@ -224,7 +224,7 @@ const (
 	admissionBackoffMax     = 96  // ceiling on the doubling backoff
 	adaptiveCycleMultiplier = 4
 	adaptiveMinCycleCap     = 1024
-	adaptiveMinCycle        = 32768
+	adaptiveMinCycle        = 8192
 )
 
 // admissionTuner self-selects a shard's admissionMode with no configuration. It
@@ -602,7 +602,36 @@ func (s *shard[K, V]) enforceSieveCapacity(
 		case p.probation.size > p.probationCap && !p.probation.empty():
 			admitFromProbation()
 		case (p.main.size > p.mainCap || s.overCapacity()) && !p.main.empty():
-			if s.evictMain(pool, stats, in, tie, defaultMainVictimScan, false) {
+			evictIn, evictTie := in, tie
+
+			inProbation := in != nil &&
+				in.sieveQ == &p.probation &&
+				p.probation.size <= p.probationCap
+
+			// loopish mirrors adaptSize: a cyclic workload is being pinned by, or is
+			// accumulating evidence toward, frequency admission. Checking evidence (not
+			// just the committed mode) keeps shouldKeep from churning main at a cycle
+			// boundary, where the current-cycle resurrection counter has just reset.
+			loopish := p.tuner.mode == admitFrequency || p.tuner.evidence > 0
+
+			shouldKeep := inProbation &&
+				p.costAdmission == CostAdmissionFrequency &&
+				s.costCap == 0 &&
+				!loopish &&
+				(p.controller.cycleMainEvicts == 0 ||
+					p.controller.resurrectionRate() < probationResurrectLow)
+
+			if shouldKeep {
+				// Probation (the recency admission window) is below target on an
+				// unweighted, non-loop, frequency-mode shard: keep the new first-touch
+				// resident and make main yield a slot instead of forcing it to beat
+				// stale sketch history before it can prove reuse. Gated off for weighted
+				// caches (costCap > 0), where keeping one large cold item would evict
+				// several main entries to free cost, and once the tuner has loop evidence
+				// or is pinning a loop, where churning main hurts the resident set.
+				evictIn, evictTie = nil, false
+			}
+			if s.evictMain(pool, stats, evictIn, evictTie, defaultMainVictimScan, false) {
 				in, tie = nil, false
 			}
 		case s.overCapacity() && !p.probation.empty():

--- a/sieve.go
+++ b/sieve.go
@@ -4,7 +4,10 @@ import "sync/atomic"
 
 const (
 	defaultProbationRatio = 1
-	defaultGhostRatio     = 100
+	// defaultGhostRatio sizes the B1 ghost as a percent of main capacity.
+	// A smaller B1 narrows the frequency core gap on stable hot set workloads
+	// (its readmissions stop repromoting cooling items).
+	defaultGhostRatio = 75
 )
 
 const (

--- a/sieve_test.go
+++ b/sieve_test.go
@@ -252,6 +252,62 @@ func TestSieveTinyLFURecordReadHitMarksVisitedOnly(t *testing.T) {
 	}
 }
 
+func TestSieveProbationWindowKeepsNewResidentWhenBelowTarget(t *testing.T) {
+	const capacity = 8
+	cfg := Config{
+		MaxSize:         capacity,
+		ShardCount:      1,
+		EvictionPolicy:  SieveTinyLFU,
+		DefaultTTL:      NoExpiration,
+		CleanupInterval: 0,
+		ProbationRatio:  50,
+		StatsEnabled:    true,
+	}
+	c, err := New[uint64, uint64](cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	for k := uint64(0); k < capacity; k++ {
+		if err := c.Set(k, k, NoExpiration); err != nil {
+			t.Fatalf("Set warm key %d: %v", k, err)
+		}
+	}
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Sync warm: %v", err)
+	}
+
+	// Make resident main entries look strong to TinyLFU. A new item should still
+	// get room in probation while that recency window is under target.
+	for i := 0; i < 32; i++ {
+		for k := uint64(0); k < capacity; k++ {
+			if _, ok := c.Get(k); !ok {
+				t.Fatalf("warm key %d disappeared before admission test", k)
+			}
+		}
+	}
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Sync frequency samples: %v", err)
+	}
+
+	if err := c.Set(100, 100, NoExpiration); err != nil {
+		t.Fatalf("Set new key: %v", err)
+	}
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Sync new key: %v", err)
+	}
+	if _, ok := c.Get(100); !ok {
+		t.Fatal("new probation resident was rejected before the probation window filled")
+	}
+	if rejects := c.PolicyStats().Rejects; rejects != 0 {
+		t.Fatalf("policy rejects=%d, want 0 while probation has room", rejects)
+	}
+	if size := c.Size(); size != capacity {
+		t.Fatalf("size=%d, want capped size %d", size, capacity)
+	}
+}
+
 func TestSieveTinyLFUAdaptiveResetCycleClearsCounters(t *testing.T) {
 	a := newSieveTinyLFU[int, int](100, 10, 100)
 

--- a/sieve_test.go
+++ b/sieve_test.go
@@ -6,8 +6,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/unkn0wn-root/kioshun/internal/keyhash"
 )
 
 func TestSieveQueuePushPopRemove(t *testing.T) {
@@ -50,56 +48,80 @@ func TestSieveQueuePushPopRemove(t *testing.T) {
 
 func TestGhostQueueAddRemoveOverwrite(t *testing.T) {
 	g := newGhostQueue(3)
-	g.add(1, 11)
-	g.add(2, 22)
-	if !g.contains(1, 11) || !g.contains(2, 22) {
+	g.add(1)
+	g.add(2)
+	if !g.contains(1) || !g.contains(2) {
 		t.Fatal("ghost queue missing inserted fingerprints")
 	}
 
-	if g.contains(1, 99) {
-		t.Fatal("hash match with wrong tag should not hit ghost queue")
-	}
-
-	if !g.remove(1, 11) {
+	if !g.remove(1) {
 		t.Fatal("delete returned false for present ghost fingerprint")
 	}
-	if g.contains(1, 11) {
+	if g.contains(1) {
 		t.Fatal("deleted fingerprint still present")
 	}
 
-	g.add(3, 33)
-	g.add(4, 44)
-	g.add(5, 55)
-	if g.contains(2, 22) {
+	g.add(3)
+	g.add(4)
+	g.add(5)
+	if g.contains(2) {
 		t.Fatal("oldest fingerprint should be overwritten")
 	}
-	for _, x := range []ghostEntry{{3, 33}, {4, 44}, {5, 55}} {
-		if !g.contains(x.hash, x.tag) {
-			t.Fatalf("fingerprint %v missing after overwrite", x)
+	for _, h := range []uint64{3, 4, 5} {
+		if !g.contains(h) {
+			t.Fatalf("fingerprint %d missing after overwrite", h)
 		}
 	}
 
 	g.clear()
-	if len(g.index) != 0 || g.contains(3, 33) || g.contains(4, 44) || g.contains(5, 55) {
+	if len(g.index) != 0 || g.contains(3) || g.contains(4) || g.contains(5) {
 		t.Fatal("clear did not reset ghost queue")
+	}
+}
+
+// hash 0 is a real fingerprint (empty-string and integer-zero keys both hash to
+// 0), so it must be tracked distinctly from the empty ring-slot sentinel.
+func TestGhostQueueZeroHashFingerprint(t *testing.T) {
+	g := newGhostQueue(2)
+	g.add(0)
+	if !g.contains(0) {
+		t.Fatal("zero-hash fingerprint not tracked")
+	}
+
+	g.add(9)
+	if !g.contains(0) || !g.contains(9) {
+		t.Fatal("zero-hash fingerprint lost after a second add")
+	}
+
+	// ring size 2: adding a third entry evicts the oldest (the zero hash).
+	g.add(8)
+	if g.contains(0) {
+		t.Fatal("oldest (zero-hash) fingerprint should have been evicted")
+	}
+	if !g.contains(9) || !g.contains(8) {
+		t.Fatal("recent fingerprints missing after eviction")
+	}
+
+	if !g.remove(8) || g.contains(8) {
+		t.Fatal("removing fingerprint adjacent to a cleared slot failed")
 	}
 }
 
 func TestGhostQueueDeleteMissingReturnsFalse(t *testing.T) {
 	g := newGhostQueue(2)
-	g.add(7, 77)
-	if g.remove(8, 88) {
+	g.add(7)
+	if g.remove(8) {
 		t.Fatal("delete returned true for missing ghost fingerprint")
 	}
-	if !g.contains(7, 77) {
+	if !g.contains(7) {
 		t.Fatal("missing delete removed existing ghost fingerprint")
 	}
 }
 
 func TestGhostQueueDuplicateDoesNotGrow(t *testing.T) {
 	g := newGhostQueue(2)
-	g.add(7, 77)
-	g.add(7, 77)
+	g.add(7)
+	g.add(7)
 	if len(g.index) != 1 {
 		t.Fatalf("n=%d, want 1", len(g.index))
 	}
@@ -168,14 +190,14 @@ func TestDoorkeeperFiltersFirstFrequencyIncrement(t *testing.T) {
 
 func TestNewSieveTinyLFUDefaults(t *testing.T) {
 	a := newSieveTinyLFU[int, int](100, 0, 0)
-	if a.probationCap != 10 || a.mainCap != 90 || a.ghostCap != 90 {
-		t.Fatalf("caps pc=%d mc=%d gc=%d, want 10/90/90", a.probationCap, a.mainCap, a.ghostCap)
+	if a.probationCap != 1 || a.mainCap != 99 || a.ghostCap != 99 {
+		t.Fatalf("caps pc=%d mc=%d gc=%d, want 1/99/99", a.probationCap, a.mainCap, a.ghostCap)
 	}
 	if a.probation.size != 0 || a.main.size != 0 || !a.probation.empty() || !a.main.empty() {
 		t.Fatal("new admission queues should be empty")
 	}
-	if len(a.ghost.entries) != 90 {
-		t.Fatalf("ghost cap=%d, want 90", len(a.ghost.entries))
+	if len(a.ghost.entries) != 99 {
+		t.Fatalf("ghost cap=%d, want 99", len(a.ghost.entries))
 	}
 	if len(a.sketch.counters) == 0 {
 		t.Fatal("sketch was not initialized")
@@ -258,7 +280,7 @@ func TestSieveTinyLFUAdaptiveShrinkUsesMainSurvivals(t *testing.T) {
 	a.controller.probationEvictions = 3
 	a.controller.promotions = 1
 	a.controller.mainSurvivals = 2
-	a.controller.observationsInCycle = uint64(a.capacity*10 - 1)
+	a.controller.observationsInCycle = uint64(a.capacity*adaptiveCycleMultiplier - 1)
 
 	a.tick()
 
@@ -285,12 +307,51 @@ func TestSieveTinyLFUAdaptiveShrinkBlockedWhenMainCold(t *testing.T) {
 	a.controller.probationEvictions = 3
 	a.controller.promotions = 1
 	a.controller.mainSurvivals = 1
-	a.controller.observationsInCycle = uint64(a.capacity*10 - 1)
+	a.controller.observationsInCycle = uint64(a.capacity*adaptiveCycleMultiplier - 1)
 
 	a.tick()
 
 	if a.probationCap != start {
 		t.Fatalf("probationCap=%d, want unchanged %d when main is cold", a.probationCap, start)
+	}
+}
+
+func TestSieveTinyLFUAdaptiveGrowBlockedByResurrection(t *testing.T) {
+	a := newSieveTinyLFU[int, int](100, 10, 100)
+	start := a.probationCap
+
+	// B1 ghost hits alone would grow probation, but B2 resurrection means main
+	// victims are still needed. The fallback grow path must honor the loop guard.
+	a.controller.ghostHits = 10
+	a.controller.probationEvictions = 4
+	a.controller.cycleMainEvicts = 10
+	a.controller.cycleB2Hits = 5
+	a.controller.observationsInCycle = uint64(a.capacity*adaptiveCycleMultiplier - 1)
+
+	a.tick()
+
+	if a.probationCap != start {
+		t.Fatalf("probationCap=%d, want unchanged %d when main victims resurrect", a.probationCap, start)
+	}
+}
+
+func TestSieveTinyLFUAdaptiveWindowFloor(t *testing.T) {
+	a := newSieveTinyLFU[int, int](2000, 1, 100)
+	start := a.probationCap
+
+	a.controller.ghostHits = 10
+	a.controller.cycleMainEvicts = 10
+	a.controller.observationsInCycle = uint64(a.capacity*adaptiveCycleMultiplier - 1)
+
+	a.tick()
+	if a.probationCap != start {
+		t.Fatalf("probationCap=%d, want unchanged before min cycle %d", a.probationCap, start)
+	}
+
+	a.controller.observationsInCycle = adaptiveMinCycle - 1
+	a.tick()
+	if a.probationCap <= start {
+		t.Fatalf("probationCap=%d, want growth after min cycle from %d", a.probationCap, start)
 	}
 }
 
@@ -342,14 +403,12 @@ func TestSieveTinyLFUExpiredFastPathDoesNotCountMainSurvival(t *testing.T) {
 		value:      1,
 		expireTime: now - int64(time.Second),
 		hash:       expiredHash,
-		tag:        keyhash.TagFromHash(expiredHash),
 	}
 	other := &cacheItem[int, int]{
 		key:        2,
 		value:      2,
 		expireTime: now + int64(time.Hour),
 		hash:       otherHash,
-		tag:        keyhash.TagFromHash(otherHash),
 	}
 
 	shard.mu.Lock()
@@ -485,8 +544,7 @@ func TestSieveTinyLFUGhostHitEntersMain(t *testing.T) {
 
 	s := c.shards[0]
 	h := c.hasher.Sum(1)
-	tag := c.hasher.Tag(1)
-	if !s.sieve.ghost.contains(h, tag) {
+	if !s.sieve.ghost.contains(h) {
 		t.Fatal("expected cold eviction to leave a ghost entry")
 	}
 
@@ -515,7 +573,7 @@ func TestSieveTinyLFUGhostHitDoesNotResizeImmediately(t *testing.T) {
 	a := newSieveTinyLFU[int, int](100, 10, 100)
 	start := a.probationCap
 	it := &cacheItem[int, int]{hash: 1}
-	a.ghost.add(it.hash, 0)
+	a.ghost.add(it.hash)
 
 	a.insert(it, true)
 

--- a/sieve_test.go
+++ b/sieve_test.go
@@ -216,14 +216,14 @@ func TestDoorkeeperFiltersFirstFrequencyIncrement(t *testing.T) {
 
 func TestNewSieveTinyLFUDefaults(t *testing.T) {
 	a := newSieveTinyLFU[int, int](100, 0, 0, 0)
-	if a.probationCap != 1 || a.mainCap != 99 || a.ghostCap != 99 {
-		t.Fatalf("caps pc=%d mc=%d gc=%d, want 1/99/99", a.probationCap, a.mainCap, a.ghostCap)
+	if a.probationCap != 1 || a.mainCap != 99 || a.ghostCap != 74 {
+		t.Fatalf("caps pc=%d mc=%d gc=%d, want 1/99/74", a.probationCap, a.mainCap, a.ghostCap)
 	}
 	if a.probation.size != 0 || a.main.size != 0 || !a.probation.empty() || !a.main.empty() {
 		t.Fatal("new admission queues should be empty")
 	}
-	if len(a.ghost.entries) != 99 {
-		t.Fatalf("ghost cap=%d, want 99", len(a.ghost.entries))
+	if len(a.ghost.entries) != 74 {
+		t.Fatalf("ghost cap=%d, want 74", len(a.ghost.entries))
 	}
 	if len(a.sketch.counters) == 0 {
 		t.Fatal("sketch was not initialized")

--- a/sieve_test.go
+++ b/sieve_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSieveQueuePushPopRemove(t *testing.T) {
 	var q sieveQueue[int, int]
-	q.init()
+	q.init(mainQueue, 0)
 	if !q.empty() {
 		t.Fatal("new segment should be empty")
 	}
@@ -25,11 +25,13 @@ func TestSieveQueuePushPopRemove(t *testing.T) {
 	if q.size != 3 {
 		t.Fatalf("n=%d, want 3", q.size)
 	}
-	if got := q.popBack(); got != a {
-		t.Fatalf("pop got=%v, want oldest item", got)
+	// The policy evicts the oldest entry as tail.prev + remove (see
+	// evictProbation/findMainVictim); exercise that pattern directly.
+	if oldest := q.tail.prev; oldest != a || !q.remove(oldest) {
+		t.Fatalf("oldest=%v, want oldest item a", oldest)
 	}
 	if a.prev != nil || a.next != nil {
-		t.Fatal("popped item links were not cleared")
+		t.Fatal("removed item links were not cleared")
 	}
 
 	if !q.remove(b) {
@@ -38,11 +40,37 @@ func TestSieveQueuePushPopRemove(t *testing.T) {
 	if q.size != 1 {
 		t.Fatalf("n=%d, want 1", q.size)
 	}
-	if got := q.popBack(); got != c {
-		t.Fatalf("pop got=%v, want remaining item", got)
+	if last := q.tail.prev; last != c || !q.remove(last) {
+		t.Fatalf("last=%v, want remaining item c", last)
 	}
 	if !q.empty() {
-		t.Fatal("segment should be empty after final pop")
+		t.Fatal("segment should be empty after final removal")
+	}
+}
+
+func TestSieveQueueOwnerIsolation(t *testing.T) {
+	var qa, qb sieveQueue[int, int]
+	qa.init(probationQueue, 1) // shard 1 probation
+	qb.init(probationQueue, 2) // shard 2 probation: same role, different owner
+
+	it := &cacheItem[int, int]{value: 1}
+	qa.pushFront(it)
+
+	if qb.holds(it) {
+		t.Fatal("queue B claims an item owned by queue A (same role, different owner)")
+	}
+	if qb.remove(it) {
+		t.Fatal("queue B removed an item owned by queue A - corruption guard failed")
+	}
+	if qb.size != 0 {
+		t.Fatalf("queue B size=%d after rejected remove, want 0", qb.size)
+	}
+	// Queue A still owns the item and can remove it.
+	if !qa.holds(it) || qa.size != 1 {
+		t.Fatal("item should remain linked in queue A")
+	}
+	if !qa.remove(it) {
+		t.Fatal("queue A failed to remove its own item")
 	}
 }
 
@@ -74,13 +102,11 @@ func TestGhostQueueAddRemoveOverwrite(t *testing.T) {
 	}
 
 	g.clear()
-	if len(g.index) != 0 || g.contains(3) || g.contains(4) || g.contains(5) {
+	if g.count() != 0 || g.contains(3) || g.contains(4) || g.contains(5) {
 		t.Fatal("clear did not reset ghost queue")
 	}
 }
 
-// hash 0 is a real fingerprint (empty-string and integer-zero keys both hash to
-// 0), so it must be tracked distinctly from the empty ring-slot sentinel.
 func TestGhostQueueZeroHashFingerprint(t *testing.T) {
 	g := newGhostQueue(2)
 	g.add(0)
@@ -122,8 +148,8 @@ func TestGhostQueueDuplicateDoesNotGrow(t *testing.T) {
 	g := newGhostQueue(2)
 	g.add(7)
 	g.add(7)
-	if len(g.index) != 1 {
-		t.Fatalf("n=%d, want 1", len(g.index))
+	if g.count() != 1 {
+		t.Fatalf("n=%d, want 1", g.count())
 	}
 }
 
@@ -162,7 +188,7 @@ func TestCountMinSketchIncrementEstimateAgeClear(t *testing.T) {
 }
 
 func TestDoorkeeperFiltersFirstFrequencyIncrement(t *testing.T) {
-	a := newSieveTinyLFU[int, int](32, 10, 100)
+	a := newSieveTinyLFU[int, int](32, 0, 10, 100)
 	h := uint64(12345)
 
 	a.recordAccess(h)
@@ -189,7 +215,7 @@ func TestDoorkeeperFiltersFirstFrequencyIncrement(t *testing.T) {
 }
 
 func TestNewSieveTinyLFUDefaults(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 0, 0)
+	a := newSieveTinyLFU[int, int](100, 0, 0, 0)
 	if a.probationCap != 1 || a.mainCap != 99 || a.ghostCap != 99 {
 		t.Fatalf("caps pc=%d mc=%d gc=%d, want 1/99/99", a.probationCap, a.mainCap, a.ghostCap)
 	}
@@ -208,7 +234,7 @@ func TestNewSieveTinyLFUDefaults(t *testing.T) {
 }
 
 func TestNewSieveTinyLFUAdaptiveBounds(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 	if a.minProbationCap != 1 || a.maxProbationCap != 60 || a.adaptStep != 1 {
 		t.Fatalf("bounds lo=%d hi=%d st=%d, want 1/60/1", a.minProbationCap, a.maxProbationCap, a.adaptStep)
 	}
@@ -225,7 +251,7 @@ func TestNewSieveTinyLFUAdaptiveBounds(t *testing.T) {
 }
 
 func TestSieveTinyLFURecordReadHitMarksVisitedOnly(t *testing.T) {
-	a := newSieveTinyLFU[int, int](16, 10, 100)
+	a := newSieveTinyLFU[int, int](16, 0, 10, 100)
 	probationItem := &cacheItem[int, int]{key: 1}
 	mainItem := &cacheItem[int, int]{key: 2}
 
@@ -269,7 +295,7 @@ func TestSieveProbationWindowKeepsNewResidentWhenBelowTarget(t *testing.T) {
 	}
 	defer c.Close()
 
-	for k := uint64(0); k < capacity; k++ {
+	for k := range uint64(capacity) {
 		if err := c.Set(k, k, NoExpiration); err != nil {
 			t.Fatalf("Set warm key %d: %v", k, err)
 		}
@@ -280,8 +306,8 @@ func TestSieveProbationWindowKeepsNewResidentWhenBelowTarget(t *testing.T) {
 
 	// Make resident main entries look strong to TinyLFU. A new item should still
 	// get room in probation while that recency window is under target.
-	for i := 0; i < 32; i++ {
-		for k := uint64(0); k < capacity; k++ {
+	for range 32 {
+		for k := range uint64(capacity) {
 			if _, ok := c.Get(k); !ok {
 				t.Fatalf("warm key %d disappeared before admission test", k)
 			}
@@ -309,7 +335,7 @@ func TestSieveProbationWindowKeepsNewResidentWhenBelowTarget(t *testing.T) {
 }
 
 func TestSieveTinyLFUAdaptiveResetCycleClearsCounters(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 
 	// Every adaptive signal lives on the single-consumer maintenance path now,
 	// so resetCycle clears them all with plain assignment, mainSurvivals included.
@@ -328,7 +354,7 @@ func TestSieveTinyLFUAdaptiveResetCycleClearsCounters(t *testing.T) {
 }
 
 func TestSieveTinyLFUAdaptiveShrinkUsesMainSurvivals(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 	start := a.probationCap
 
 	// Probation churns (evictions > 2x promotions) and main is warm
@@ -355,7 +381,7 @@ func TestSieveTinyLFUAdaptiveShrinkUsesMainSurvivals(t *testing.T) {
 }
 
 func TestSieveTinyLFUAdaptiveShrinkBlockedWhenMainCold(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 	start := a.probationCap
 
 	// Probation churns, but main earns nothing (survivals <= promotions): the
@@ -373,7 +399,7 @@ func TestSieveTinyLFUAdaptiveShrinkBlockedWhenMainCold(t *testing.T) {
 }
 
 func TestSieveTinyLFUAdaptiveGrowBlockedByResurrection(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 	start := a.probationCap
 
 	// B1 ghost hits alone would grow probation, but B2 resurrection means main
@@ -392,7 +418,7 @@ func TestSieveTinyLFUAdaptiveGrowBlockedByResurrection(t *testing.T) {
 }
 
 func TestSieveTinyLFUAdaptiveWindowFloor(t *testing.T) {
-	a := newSieveTinyLFU[int, int](2000, 1, 100)
+	a := newSieveTinyLFU[int, int](2000, 0, 1, 100)
 	start := a.probationCap
 
 	a.controller.ghostHits = 10
@@ -412,7 +438,7 @@ func TestSieveTinyLFUAdaptiveWindowFloor(t *testing.T) {
 }
 
 func TestSieveTinyLFUMainSweepCountsSurvivals(t *testing.T) {
-	a := newSieveTinyLFU[int, int](16, 10, 100)
+	a := newSieveTinyLFU[int, int](16, 0, 10, 100)
 	spared := &cacheItem[int, int]{key: 1}
 	victim := &cacheItem[int, int]{key: 2}
 	a.insertMain(spared)
@@ -468,8 +494,8 @@ func TestSieveTinyLFUExpiredFastPathDoesNotCountMainSurvival(t *testing.T) {
 	}
 
 	shard.mu.Lock()
-	shard.data[1] = expired
-	shard.data[2] = other
+	shard.tab.store(expired)
+	shard.tab.store(other)
 	atomic.StoreInt64(&shard.size, 2)
 	shard.sieve.insertMain(expired)
 	shard.sieve.insert(other, false)
@@ -551,7 +577,7 @@ func TestNonAdmissionPolicyDoesNotInitializeAdmissionState(t *testing.T) {
 }
 
 func TestSieveTinyLFUBoundedVictimNeedsForce(t *testing.T) {
-	a := newSieveTinyLFU[int, int](8, 25, 100)
+	a := newSieveTinyLFU[int, int](8, 0, 25, 100)
 	for k := 1; k <= 4; k++ {
 		a.insertMain(&cacheItem[int, int]{
 			key:     k,
@@ -608,7 +634,7 @@ func TestSieveTinyLFUGhostHitEntersMain(t *testing.T) {
 	waitForWrites(t, c)
 
 	s.mu.RLock()
-	it, ok := s.data[1]
+	it, ok := s.tab.lookup(c.hasher.Sum(1), 1)
 	if !ok {
 		s.mu.RUnlock()
 		t.Fatal("ghost hit candidate was not resident")
@@ -626,7 +652,7 @@ func TestSieveTinyLFUGhostHitEntersMain(t *testing.T) {
 }
 
 func TestSieveTinyLFUGhostHitDoesNotResizeImmediately(t *testing.T) {
-	a := newSieveTinyLFU[int, int](100, 10, 100)
+	a := newSieveTinyLFU[int, int](100, 0, 10, 100)
 	start := a.probationCap
 	it := &cacheItem[int, int]{hash: 1}
 	a.ghost.add(it.hash)
@@ -645,11 +671,8 @@ func TestSieveTinyLFUGhostHitDoesNotResizeImmediately(t *testing.T) {
 }
 
 func TestSieveTinyLFUMaintainForcesCapacityAfterBoundedScan(t *testing.T) {
-	s := &shard[int, int]{data: make(map[int]*cacheItem[int, int]), cap: 3}
-	s.initLRU()
-	s.sieve = newSieveTinyLFU[int, int](3, 25, 100)
-	var p sync.Pool
-	p.New = func() any { return &cacheItem[int, int]{} }
+	s := &shard[int, int]{tab: newHtable[int, int](3), cap: 3, stats: newStats(1)}
+	s.sieve = newSieveTinyLFU[int, int](3, 0, 25, 100)
 
 	var in *cacheItem[int, int]
 	for k := 1; k <= 4; k++ {
@@ -660,7 +683,7 @@ func TestSieveTinyLFUMaintainForcesCapacityAfterBoundedScan(t *testing.T) {
 			reuse:   1,
 			visited: sieveVisited,
 		}
-		s.data[k] = it
+		s.tab.store(it)
 		s.sieve.insertMain(it)
 		atomic.AddInt64(&s.size, 1)
 		if k == 4 {
@@ -668,7 +691,7 @@ func TestSieveTinyLFUMaintainForcesCapacityAfterBoundedScan(t *testing.T) {
 		}
 	}
 
-	s.enforceSieveCapacity(&p, true, in, true)
+	s.enforceSieveCapacity(true, in, true)
 
 	if sz := atomic.LoadInt64(&s.size); sz > s.cap {
 		t.Fatalf("size=%d exceeds cap=%d", sz, s.cap)
@@ -771,7 +794,7 @@ func TestSieveTinyLFUExistingUpdatePromotesProbation(t *testing.T) {
 
 	s := c.shards[0]
 	s.mu.RLock()
-	it := s.data[1]
+	it, _ := s.tab.lookup(c.hasher.Sum(1), 1)
 	q := it.queue
 	v := it.value
 	s.mu.RUnlock()
@@ -808,7 +831,7 @@ func TestSieveTinyLFUDeleteUnlinksQueue(t *testing.T) {
 	s.mu.RLock()
 	n := s.sieve.probation.size + s.sieve.main.size
 	sz := atomic.LoadInt64(&s.size)
-	_, ok := s.data[1]
+	_, ok := s.tab.lookup(c.hasher.Sum(1), 1)
 	s.mu.RUnlock()
 
 	if ok {
@@ -839,8 +862,8 @@ func TestSieveTinyLFUClearResetsPolicyState(t *testing.T) {
 	if atomic.LoadInt64(&s.size) != 0 {
 		t.Fatalf("size=%d, want 0", atomic.LoadInt64(&s.size))
 	}
-	if s.sieve.probation.size != 0 || s.sieve.main.size != 0 || len(s.sieve.ghost.index) != 0 {
-		t.Fatalf("policy state not cleared: p=%d m=%d g=%d", s.sieve.probation.size, s.sieve.main.size, len(s.sieve.ghost.index))
+	if s.sieve.probation.size != 0 || s.sieve.main.size != 0 || s.sieve.ghost.count() != 0 {
+		t.Fatalf("policy state not cleared: p=%d m=%d g=%d", s.sieve.probation.size, s.sieve.main.size, s.sieve.ghost.count())
 	}
 }
 
@@ -878,11 +901,8 @@ func TestSieveTinyLFUCleanupRemovesExpiredQueueItem(t *testing.T) {
 }
 
 func TestSieveTinyLFUMainSieveEvictionClearsVisited(t *testing.T) {
-	s := &shard[int, int]{data: make(map[int]*cacheItem[int, int])}
-	s.initLRU()
-	s.sieve = newSieveTinyLFU[int, int](4, 25, 100)
-	var p sync.Pool
-	p.New = func() any { return &cacheItem[int, int]{} }
+	s := &shard[int, int]{tab: newHtable[int, int](4), stats: newStats(1)}
+	s.sieve = newSieveTinyLFU[int, int](4, 0, 25, 100)
 
 	for k := 1; k <= 3; k++ {
 		it := &cacheItem[int, int]{
@@ -892,19 +912,19 @@ func TestSieveTinyLFUMainSieveEvictionClearsVisited(t *testing.T) {
 			reuse:   1,
 			visited: sieveVisited,
 		}
-		s.data[k] = it
+		s.tab.store(it)
 		s.sieve.insertMain(it)
 		atomic.AddInt64(&s.size, 1)
 	}
 
-	if ok := s.evictMain(&p, true, nil, false, s.sieve.main.size+1, true); !ok {
+	if ok := s.evictMain(true, nil, false, s.sieve.main.size+1, true); !ok {
 		t.Fatal("main eviction returned false")
 	}
-	if _, ok := s.data[1]; ok {
+	if _, ok := s.tab.lookup(1, 1); ok {
 		t.Fatal("expected oldest hand item to be evicted after visited-bit sweep")
 	}
 	for _, k := range []int{2, 3} {
-		it := s.data[k]
+		it, _ := s.tab.lookup(uint64(k), k)
 		if it == nil {
 			t.Fatalf("item %d missing", k)
 		}
@@ -915,8 +935,8 @@ func TestSieveTinyLFUMainSieveEvictionClearsVisited(t *testing.T) {
 	if s.sieve.main.size != 2 {
 		t.Fatalf("main size=%d, want 2", s.sieve.main.size)
 	}
-	if atomic.LoadInt64(&s.evictions) != 1 {
-		t.Fatalf("evictions=%d, want 1", atomic.LoadInt64(&s.evictions))
+	if _, _, ev, _ := s.stats.aggregate(); ev != 1 {
+		t.Fatalf("evictions=%d, want 1", ev)
 	}
 	if s.sieve.stats.MainEvictions != 1 {
 		t.Fatalf("main evictions=%d, want 1", s.sieve.stats.MainEvictions)
@@ -924,7 +944,7 @@ func TestSieveTinyLFUMainSieveEvictionClearsVisited(t *testing.T) {
 }
 
 func TestSieveTinyLFUEqualFrequencyTieRejection(t *testing.T) {
-	a := newSieveTinyLFU[int, int](4, 25, 100)
+	a := newSieveTinyLFU[int, int](4, 0, 25, 100)
 	in := &cacheItem[int, int]{hash: 11}
 	v := &cacheItem[int, int]{hash: 22, queue: mainQueue, reuse: 1}
 
@@ -945,6 +965,134 @@ func TestSieveTinyLFUEqualFrequencyTieRejection(t *testing.T) {
 	if !a.shouldAdmit(in, v, false) {
 		t.Fatal("unvisited zero-reuse victim should lose equal-frequency tie")
 	}
+}
+
+// TestSieveDropUnpublishedCandidateIsTableFreeAndIdempotent locks down the
+// late-publication drop contract. A rejected candidate is live in policy but was
+// never stored, so the drop must unlink it policy-only without touching the table,
+// and a redundant second drop must be a no-op - the cleared unpublished flag falls
+// through to removeExact, which fails because nothing was ever stored, so there is
+// no double policy-unlink and no size underflow.
+func TestSieveDropUnpublishedCandidateIsTableFreeAndIdempotent(t *testing.T) {
+	s := &shard[int, int]{tab: newHtable[int, int](4), cap: 4, stats: newStats(1)}
+	s.sieve = newSieveTinyLFU[int, int](4, 0, 25, 100)
+
+	// A published resident the candidate drop must leave untouched.
+	resident := &cacheItem[int, int]{key: 1, value: 1, hash: 1}
+	s.tab.store(resident)
+	s.sieve.insertMain(resident)
+	atomic.AddInt64(&s.size, 1)
+
+	// An unpublished candidate: linked into policy, deliberately absent from the
+	// table, exactly as applySieve holds a candidate during admission.
+	cand := &cacheItem[int, int]{key: 2, value: 2, hash: 2, unpublished: true}
+	s.sieve.insert(cand, false)
+	atomic.AddInt64(&s.size, 1)
+	if _, ok := s.tab.lookup(cand.hash, cand.key); ok {
+		t.Fatal("candidate must not be in the table before any drop")
+	}
+
+	if !s.dropSieveItem(cand, false, RemovedRejected) {
+		t.Fatal("dropping an unpublished candidate returned false")
+	}
+	if cand.unpublished {
+		t.Fatal("drop did not clear the unpublished flag")
+	}
+	if s.sieve.owns(cand) {
+		t.Fatal("drop left the candidate linked in a policy queue")
+	}
+	if _, ok := s.tab.lookup(cand.hash, cand.key); ok {
+		t.Fatal("drop published a candidate that was never stored")
+	}
+	if sz := atomic.LoadInt64(&s.size); sz != 1 {
+		t.Fatalf("size=%d after reject, want 1 (only the resident)", sz)
+	}
+
+	// Self-healing: re-dropping the same pointer is a no-op via removeExact.
+	if s.dropSieveItem(cand, false, RemovedRejected) {
+		t.Fatal("re-dropping a rejected candidate must be a no-op")
+	}
+	if sz := atomic.LoadInt64(&s.size); sz != 1 {
+		t.Fatalf("size=%d after redundant drop, want 1", sz)
+	}
+
+	// The resident is untouched: still in the table and still policy-owned.
+	if _, ok := s.tab.lookup(resident.hash, resident.key); !ok {
+		t.Fatal("resident vanished after dropping the candidate")
+	}
+	if !s.sieve.owns(resident) {
+		t.Fatal("resident lost its policy linkage")
+	}
+	if n := s.tab.length(); n != 1 {
+		t.Fatalf("table length=%d, want 1", n)
+	}
+}
+
+// TestSieveRejectedCandidateNeverPublished drives the real applySieve insert path
+// and forces a reject (a cold candidate under frequency admission cannot beat hot
+// incumbents). The rejected candidate must never reach the table - invisible to a
+// lock-free Get - and leave size and the policy queues consistent.
+func TestSieveRejectedCandidateNeverPublished(t *testing.T) {
+	c := newTestCache[int, int](t, Config{
+		MaxSize:         2,
+		ShardCount:      1,
+		CleanupInterval: 0,
+		DefaultTTL:      time.Hour,
+		EvictionPolicy:  SieveTinyLFU,
+		StatsEnabled:    true,
+	})
+	defer c.Close()
+
+	s := c.shards[0]
+	p := s.sieve
+
+	// Seed two hot, evictable main residents and pin frequency admission so a
+	// never-seen candidate is rejected deterministically.
+	s.mu.Lock()
+	for _, k := range []int{1, 2} {
+		it := &cacheItem[int, int]{key: k, value: k, hash: c.hasher.Sum(k)}
+		s.tab.store(it)
+		p.insertMain(it)
+		clearSieveItemVisited(it) // no second chance: the hand evicts on first pass
+		it.reuse = 0
+		atomic.AddInt64(&s.size, 1)
+		for range 8 {
+			p.sketch.increment(it.hash) // make the incumbents look hot
+		}
+	}
+	p.tuner.mode = admitFrequency
+	s.mu.Unlock()
+
+	_, cmd, err := c.setCommand(99, 99, time.Hour, nil)
+	if err != nil {
+		t.Fatalf("setCommand: %v", err)
+	}
+	s.mu.Lock()
+	committed := c.applySieve(s, &cmd)
+	s.mu.Unlock()
+
+	if committed {
+		t.Fatal("cold candidate was admitted under frequency mode, want reject")
+	}
+	if _, ok := c.Get(99); ok {
+		t.Fatal("rejected candidate is visible to Get; it must never be published")
+	}
+
+	s.mu.RLock()
+	_, inTable := s.tab.lookup(cmd.hash, 99)
+	sz := atomic.LoadInt64(&s.size)
+	s.mu.RUnlock()
+
+	if inTable {
+		t.Fatal("rejected candidate left a slot in the table")
+	}
+	if sz != 2 {
+		t.Fatalf("size=%d after reject, want 2 (insert increment was undone)", sz)
+	}
+	if rejects := c.PolicyStats().Rejects; rejects != 1 {
+		t.Fatalf("policy rejects=%d, want 1", rejects)
+	}
+	assertSieveShardConsistent(t, s)
 }
 
 func TestSieveTinyLFUQueueSizeMatchesShardSizeAfterMixedOps(t *testing.T) {
@@ -1124,26 +1272,25 @@ func assertSieveShardConsistent[K comparable, V any](t *testing.T, s *shard[K, V
 	if s.sieve == nil {
 		t.Fatal("missing sieve policy state")
 	}
-	if int64(len(s.data)) != atomic.LoadInt64(&s.size) {
-		t.Fatalf("map size=%d, shard size=%d", len(s.data), atomic.LoadInt64(&s.size))
+	n := s.tab.length()
+	if int64(n) != atomic.LoadInt64(&s.size) {
+		t.Fatalf("table size=%d, shard size=%d", n, atomic.LoadInt64(&s.size))
 	}
 
-	seen := make(map[*cacheItem[K, V]]struct{}, len(s.data))
-	pn := assertSieveQueueConsistent(t, &s.sieve.probation, probationQueue, len(s.data), seen)
-	mn := assertSieveQueueConsistent(t, &s.sieve.main, mainQueue, len(s.data), seen)
+	seen := make(map[*cacheItem[K, V]]struct{}, n)
+	pn := assertSieveQueueConsistent(t, &s.sieve.probation, probationQueue, n, seen)
+	mn := assertSieveQueueConsistent(t, &s.sieve.main, mainQueue, n, seen)
 	total := pn + mn
 	if total != atomic.LoadInt64(&s.size) {
 		t.Fatalf("queue size=%d, shard size=%d", total, atomic.LoadInt64(&s.size))
 	}
 
-	for key, item := range s.data {
+	s.tab.forEach(func(item *cacheItem[K, V]) bool {
 		if _, ok := seen[item]; !ok {
-			t.Fatalf("resident key %v is not linked in any Sieve queue", key)
+			t.Fatalf("resident key %v is not linked in any Sieve queue", item.key)
 		}
-		if item.key != key {
-			t.Fatalf("resident key %v stored item key=%v", key, item.key)
-		}
-	}
+		return true
+	})
 }
 
 func assertSieveQueueConsistent[K comparable, V any](
@@ -1177,11 +1324,8 @@ func assertSieveQueueConsistent[K comparable, V any](
 		if it.next == nil || it.next.prev != it {
 			t.Fatal("queue next/prev linkage is inconsistent")
 		}
-		if it.sieveQ != q {
-			t.Fatalf("item queue owner mismatch: got %p want %p", it.sieveQ, q)
-		}
-		if it.queue != id {
-			t.Fatalf("item queue id=%d, want %d", it.queue, id)
+		if it.queue != id || it.queue != q.id {
+			t.Fatalf("item queue id=%d, want %d (q.id=%d)", it.queue, id, q.id)
 		}
 		if _, ok := seen[it]; ok {
 			t.Fatal("item is linked in multiple Sieve queues")

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,42 @@
+package kioshun
+
+import "sync/atomic"
+
+const statStripeCap = 16
+
+type statStripe struct {
+	hits        atomic.Int64
+	misses      atomic.Int64
+	evictions   atomic.Int64
+	expirations atomic.Int64
+	_           [cacheLinePadding]byte
+}
+
+type stats struct {
+	stripes []statStripe
+	mask    uint64
+}
+
+func newStats(parallelism int) *stats {
+	n := max(nextPowerOf2(min(parallelism, statStripeCap)), 1)
+	return &stats{stripes: make([]statStripe, n), mask: uint64(n - 1)}
+}
+
+func (s *stats) stripe() *statStripe {
+	return &s.stripes[uint64(procID())&s.mask]
+}
+
+func (s *stats) recordHit()        { s.stripe().hits.Add(1) }
+func (s *stats) recordMiss()       { s.stripe().misses.Add(1) }
+func (s *stats) recordEviction()   { s.stripe().evictions.Add(1) }
+func (s *stats) recordExpiration() { s.stripe().expirations.Add(1) }
+
+func (s *stats) aggregate() (hits, misses, evictions, expirations int64) {
+	for i := range s.stripes {
+		hits += s.stripes[i].hits.Load()
+		misses += s.stripes[i].misses.Load()
+		evictions += s.stripes[i].evictions.Load()
+		expirations += s.stripes[i].expirations.Load()
+	}
+	return
+}

--- a/writes.go
+++ b/writes.go
@@ -3,8 +3,6 @@ package kioshun
 import (
 	"sync/atomic"
 	"time"
-
-	"github.com/unkn0wn-root/kioshun/internal/keyhash"
 )
 
 type writeOp uint8
@@ -27,7 +25,7 @@ type writeCommand[K comparable, V any] struct {
 	hash       uint64
 	expireTime int64
 	now        int64
-	tag        uint16
+	cost       int64
 	op         writeOp
 	result     chan struct{}
 	extra      *writeExtra[K, V]
@@ -69,16 +67,22 @@ func (cmd *writeCommand[K, V]) newCallbackTask(committed bool) (callbackTask[K, 
 }
 
 func (c *Cache[K, V]) set(key K, value V, ttl time.Duration, callback func(K, V)) error {
-	s, cmd := c.setCommand(key, value, ttl, callback)
+	s, cmd, err := c.setCommand(key, value, ttl, callback)
+	if err != nil {
+		return err
+	}
 	return c.enqueue(s, cmd)
 }
 
 func (c *Cache[K, V]) setAndWait(key K, value V, ttl time.Duration, callback func(K, V)) error {
-	s, cmd := c.setCommand(key, value, ttl, callback)
+	s, cmd, err := c.setCommand(key, value, ttl, callback)
+	if err != nil {
+		return err
+	}
 	return c.applySetSync(s, cmd)
 }
 
-func (c *Cache[K, V]) setCommand(key K, value V, ttl time.Duration, callback func(K, V)) (*shard[K, V], writeCommand[K, V]) {
+func (c *Cache[K, V]) setCommand(key K, value V, ttl time.Duration, callback func(K, V)) (*shard[K, V], writeCommand[K, V], error) {
 	if ttl == DefaultExpiration {
 		ttl = c.config.DefaultTTL
 	}
@@ -90,19 +94,44 @@ func (c *Cache[K, V]) setCommand(key K, value V, ttl time.Duration, callback fun
 	}
 
 	kh := c.hasher.Sum(key)
+	cost, err := c.itemCost(key, value)
+	if err != nil {
+		return nil, writeCommand[K, V]{}, err
+	}
+	shard := c.shardByHash(kh)
+	if shard.costCap > 0 && cost > shard.costCap {
+		return nil, writeCommand[K, V]{}, ErrItemTooLarge
+	}
 	cmd := writeCommand[K, V]{
 		op:         writeSet,
 		key:        key,
 		value:      value,
 		hash:       kh,
-		tag:        keyhash.TagFromHash(kh),
 		now:        now,
 		expireTime: expireTime,
+		cost:       cost,
 	}
 	if callback != nil {
 		cmd.extra = &writeExtra[K, V]{callback: callback}
 	}
-	return c.shardByHash(kh), cmd
+	return shard, cmd, nil
+}
+
+func (c *Cache[K, V]) itemCost(key K, value V) (int64, error) {
+	if !c.trackCost {
+		return 0, nil
+	}
+	cost := int64(1)
+	if c.weigher != nil {
+		cost = c.weigher(key, value)
+	}
+	if cost < 0 {
+		return 0, ErrInvalidCost
+	}
+	if cost == 0 {
+		return 0, nil
+	}
+	return cost, nil
 }
 
 // enqueue is the async producer boundary: closed caches fail immediately and a
@@ -154,7 +183,7 @@ func (c *Cache[K, V]) syncMutate(s *shard[K, V], apply func()) error {
 		return ErrCacheClosed
 	}
 
-	c.drainShardLocked(s)
+	c.drainShardQueue(s)
 
 	s.mu.Lock()
 	apply()
@@ -166,7 +195,7 @@ func (c *Cache[K, V]) applySetSync(s *shard[K, V], cmd writeCommand[K, V]) error
 	var task callbackTask[K, V]
 	var hasTask bool
 	err := c.syncMutate(s, func() {
-		committed := c.applySetLocked(s, &cmd)
+		committed := c.applySet(s, &cmd)
 		task, hasTask = cmd.newCallbackTask(committed)
 	})
 	if err != nil {
@@ -181,7 +210,7 @@ func (c *Cache[K, V]) applySetSync(s *shard[K, V], cmd writeCommand[K, V]) error
 func (c *Cache[K, V]) deleteSync(s *shard[K, V], key K) (bool, error) {
 	var deleted bool
 	err := c.syncMutate(s, func() {
-		deleted = c.deleteLocked(s, key)
+		deleted = c.deleteKey(s, key)
 	})
 	return deleted, err
 }
@@ -236,7 +265,7 @@ func (c *Cache[K, V]) enqueueBarrierAll(op writeOp) error {
 func (c *Cache[K, V]) clearDirect() {
 	for _, s := range c.shards {
 		s.mu.Lock()
-		c.clearShardLocked(s)
+		c.clearShard(s)
 		s.mu.Unlock()
 	}
 }
@@ -263,17 +292,19 @@ func (c *Cache[K, V]) tryDrainShard(s *shard[K, V]) {
 	if !s.drainMu.TryLock() {
 		return
 	}
-	c.drainShardLocked(s)
+	c.drainShardQueue(s)
 	s.drainMu.Unlock()
 }
 
 func (c *Cache[K, V]) drainShard(s *shard[K, V]) {
 	s.drainMu.Lock()
-	c.drainShardLocked(s)
+	c.drainShardQueue(s)
 	s.drainMu.Unlock()
 }
 
-func (c *Cache[K, V]) drainShardLocked(s *shard[K, V]) {
+// drainShardQueue consumes read samples and queued writes. The caller must hold
+// s.drainMu so there is only one shard consumer.
+func (c *Cache[K, V]) drainShardQueue(s *shard[K, V]) {
 	batch := s.writeBatch
 
 	s.drainReadSamples()
@@ -297,7 +328,7 @@ func (c *Cache[K, V]) applyWriteBatch(s *shard[K, V], batch []writeCommand[K, V]
 		cmd := &batch[i]
 		switch cmd.op {
 		case writeSet:
-			committed := c.applySetLocked(s, cmd)
+			committed := c.applySet(s, cmd)
 			if t, ok := cmd.newCallbackTask(committed); ok {
 				callbacks = append(callbacks, t)
 			}
@@ -305,7 +336,7 @@ func (c *Cache[K, V]) applyWriteBatch(s *shard[K, V], batch []writeCommand[K, V]
 				acks = append(acks, ch)
 			}
 		case writeClear:
-			c.clearShardLocked(s)
+			c.clearShard(s)
 			if ch := cmd.resultChan(); ch != nil {
 				acks = append(acks, ch)
 			}
@@ -333,18 +364,24 @@ func (c *Cache[K, V]) newItem(cmd *writeCommand[K, V]) *cacheItem[K, V] {
 	item.lastAccess = cmd.now
 	item.key = cmd.key
 	item.hash = cmd.hash
-	item.tag = cmd.tag
 	item.expireTime = cmd.expireTime
+	item.cost = cmd.cost
 	return item
 }
 
-func (c *Cache[K, V]) applySetLocked(s *shard[K, V], cmd *writeCommand[K, V]) bool {
+// applySet mutates shard contents and policy state. The caller must hold s.mu.
+func (c *Cache[K, V]) applySet(s *shard[K, V], cmd *writeCommand[K, V]) bool {
+	cmdCost := cmd.cost
 	if ex, exists := s.data[cmd.key]; exists {
+		costDelta := cmdCost - ex.cost
 		ex.value = cmd.value
 		ex.lastAccess = cmd.now
 		ex.expireTime = cmd.expireTime
 		ex.hash = cmd.hash
-		ex.tag = cmd.tag
+		if costDelta != 0 {
+			ex.cost = cmdCost
+			atomic.AddInt64(&s.cost, costDelta)
+		}
 
 		switch c.config.EvictionPolicy {
 		case LRU:
@@ -355,15 +392,16 @@ func (c *Cache[K, V]) applySetLocked(s *shard[K, V], cmd *writeCommand[K, V]) bo
 			s.lfuList.add(ex)
 		case SieveTinyLFU:
 			ex.lfuFreq = 0
-			if s.sieve != nil && !s.belowSieveWarmupLocked() {
+			if s.sieve != nil && !s.belowSieveWarmup() {
 				s.sieve.recordUpdate(ex)
 			}
 		}
+		c.enforcePostUpdateCapacity(s)
 		return true
 	}
 
 	if c.config.EvictionPolicy == SieveTinyLFU && s.sieve != nil {
-		warmup := s.belowSieveWarmupLocked()
+		warmup := s.belowSieveWarmup()
 		if !warmup {
 			s.sieve.recordAccess(cmd.hash)
 		}
@@ -371,10 +409,13 @@ func (c *Cache[K, V]) applySetLocked(s *shard[K, V], cmd *writeCommand[K, V]) bo
 		item := c.newItem(cmd)
 		s.data[cmd.key] = item
 		atomic.AddInt64(&s.size, 1)
+		if item.cost != 0 {
+			atomic.AddInt64(&s.cost, item.cost)
+		}
 
-		ghostHit := !warmup && s.sieve.ghost.contains(cmd.hash, cmd.tag)
+		ghostHit := !warmup && s.sieve.ghost.contains(cmd.hash)
 		s.sieve.insert(item, ghostHit)
-		if !warmup {
+		if !warmup || s.overCapacity() {
 			s.enforceSieveCapacity(&c.itemPool, c.config.StatsEnabled, item, ghostHit)
 		}
 		if _, ok := s.data[cmd.key]; ok {
@@ -386,7 +427,7 @@ func (c *Cache[K, V]) applySetLocked(s *shard[K, V], cmd *writeCommand[K, V]) bo
 	}
 
 	// non-Sieve policies evict before inserting so the new item is not selected.
-	if s.cap > 0 && atomic.LoadInt64(&s.size) >= s.cap {
+	for s.wouldOverCapacity(cmdCost) && len(s.data) > 0 {
 		c.evictor.evict(s, &c.itemPool, c.config.StatsEnabled)
 	}
 
@@ -399,10 +440,29 @@ func (c *Cache[K, V]) applySetLocked(s *shard[K, V], cmd *writeCommand[K, V]) bo
 	}
 
 	atomic.AddInt64(&s.size, 1)
+	if item.cost != 0 {
+		atomic.AddInt64(&s.cost, item.cost)
+	}
 	return true
 }
 
-func (c *Cache[K, V]) deleteLocked(s *shard[K, V], key K) bool {
+// enforcePostUpdateCapacity restores capacity after updating an existing item.
+// The caller must hold s.mu.
+func (c *Cache[K, V]) enforcePostUpdateCapacity(s *shard[K, V]) {
+	if !s.overCapacity() {
+		return
+	}
+	if c.config.EvictionPolicy == SieveTinyLFU && s.sieve != nil {
+		s.enforceSieveCapacity(&c.itemPool, c.config.StatsEnabled, nil, false)
+		return
+	}
+	for s.overCapacity() && len(s.data) > 0 {
+		c.evictor.evict(s, &c.itemPool, c.config.StatsEnabled)
+	}
+}
+
+// deleteKey removes key from a shard. The caller must hold s.mu.
+func (c *Cache[K, V]) deleteKey(s *shard[K, V], key K) bool {
 	item, exists := s.data[key]
 	if !exists {
 		return false
@@ -411,7 +471,8 @@ func (c *Cache[K, V]) deleteLocked(s *shard[K, V], key K) bool {
 	return true
 }
 
-func (c *Cache[K, V]) clearShardLocked(s *shard[K, V]) {
+// clearShard resets a shard's contents and policy state. The caller must hold s.mu.
+func (c *Cache[K, V]) clearShard(s *shard[K, V]) {
 	for _, item := range s.data {
 		releaseCacheItem(&c.itemPool, item)
 	}
@@ -424,6 +485,7 @@ func (c *Cache[K, V]) clearShardLocked(s *shard[K, V]) {
 		s.sieve.reset()
 	}
 	atomic.StoreInt64(&s.size, 0)
+	atomic.StoreInt64(&s.cost, 0)
 }
 
 func (c *Cache[K, V]) scheduleCallback(task callbackTask[K, V]) {

--- a/writes.go
+++ b/writes.go
@@ -71,7 +71,52 @@ func (c *Cache[K, V]) set(key K, value V, ttl time.Duration, callback func(K, V)
 	if err != nil {
 		return err
 	}
+	if c.tryApplyInline(s, &cmd) {
+		return nil
+	}
 	return c.enqueue(s, cmd)
+}
+
+// tryApplyInline opportunistically applies a Set synchronously when the shard is
+// completely uncontended: the drain token is free, the write queue is fully
+// quiescent (no slot reserved or published), and the shard lock is immediately
+// available. Applying inline gives immediate read-after-write visibility and skips
+// the async handoff, which otherwise lets a re-read miss the not-yet-applied write
+// and enqueue a redundant Set.
+//
+// Holding the drain token makes this the sole shard consumer, and quiescent rules
+// out any accepted-but-unpublished write, so applying ahead of the queue cannot
+// reorder against a queued write. It mirrors the worker's drain order - buffered
+// reads are replayed into the frequency sketch before admission - so an inline Set
+// makes the same SieveTinyLFU decision a queued one would.
+//
+// Every acquisition is non-blocking (TryLock), so this never delays SetAsync: any
+// contention - a busy drain worker, queued or in-flight writes, or an active
+// reader/writer on the shard - makes it return false and leave the write for the
+// async queue, preserving both the enqueue-only SetAsync contract and the batching
+// that amortizes eviction on write-heavy shards.
+func (c *Cache[K, V]) tryApplyInline(s *shard[K, V], cmd *writeCommand[K, V]) bool {
+	if !s.drainMu.TryLock() {
+		return false
+	}
+	if c.isClosed() || !s.queue.quiescent() || !s.mu.TryLock() {
+		s.drainMu.Unlock()
+		return false
+	}
+
+	// Replay buffered reads into the sketch before admission so the inline apply
+	// makes the same SieveTinyLFU decision a queued write would. This runs only
+	// after winning s.mu, so a SetAsync that cannot commit inline bails to the
+	// queue cheaply; the worker drains read samples before applying it anyway.
+	s.drainReadSamples()
+	committed := c.applySet(s, cmd)
+	s.mu.Unlock()
+	s.drainMu.Unlock()
+
+	if task, ok := cmd.newCallbackTask(committed); ok {
+		c.scheduleCallback(task)
+	}
+	return true
 }
 
 func (c *Cache[K, V]) setAndWait(key K, value V, ttl time.Duration, callback func(K, V)) error {

--- a/writes.go
+++ b/writes.go
@@ -24,7 +24,6 @@ type writeCommand[K comparable, V any] struct {
 	value      V
 	hash       uint64
 	expireTime int64
-	now        int64
 	cost       int64
 	op         writeOp
 	result     chan struct{}
@@ -152,7 +151,6 @@ func (c *Cache[K, V]) setCommand(key K, value V, ttl time.Duration, callback fun
 		key:        key,
 		value:      value,
 		hash:       kh,
-		now:        now,
 		expireTime: expireTime,
 		cost:       cost,
 	}
@@ -214,8 +212,7 @@ func (c *Cache[K, V]) releaseWriteWaiter(waiter *writeWaiter) {
 // syncMutate is the synchronous write path shared by Set and Delete. It
 // takes drainMu (the queue's single-consumer token), flushes queued writes so
 // the direct mutation observes prior writes in order, then mutates under the
-// shard lock. The closed-check is repeated after drainMu is held so a concurrent
-// Close cannot race past the barrier into a shard being torn down.
+// shard lock.
 func (c *Cache[K, V]) syncMutate(s *shard[K, V], apply func()) error {
 	if c.isClosed() {
 		return ErrCacheClosed
@@ -252,10 +249,10 @@ func (c *Cache[K, V]) applySetSync(s *shard[K, V], cmd writeCommand[K, V]) error
 	return nil
 }
 
-func (c *Cache[K, V]) deleteSync(s *shard[K, V], key K) (bool, error) {
+func (c *Cache[K, V]) deleteSync(s *shard[K, V], kh uint64, key K) (bool, error) {
 	var deleted bool
 	err := c.syncMutate(s, func() {
-		deleted = c.deleteKey(s, key)
+		deleted = c.deleteKey(s, kh, key)
 	})
 	return deleted, err
 }
@@ -286,7 +283,6 @@ func (c *Cache[K, V]) enqueueBarrierAll(op writeOp) error {
 		waiter := c.acquireWriteWaiter()
 		cmd := writeCommand[K, V]{
 			op:     op,
-			now:    time.Now().UnixNano(),
 			result: waiter.ch,
 		}
 		if err := s.queue.enqueue(cmd); err != nil {
@@ -347,6 +343,23 @@ func (c *Cache[K, V]) drainShard(s *shard[K, V]) {
 	s.drainMu.Unlock()
 }
 
+// drainMissAndLookup restores read-after-write visibility for the lock-free read
+// path. A SieveTinyLFU read takes no lock, so it never waits for the write
+// worker; a miss may therefore be a Set still sitting in this shard's async
+// queue. When the queue is non-empty this drains it (without blocking - it only
+// helps when it can claim the single-consumer token) and re-checks, so a Get that
+// races a Set of the same key still observes it. This keeps writes batched (the
+// async pipeline is untouched) while paying the catch-up cost only on the miss
+// path, where a stale miss would otherwise re-enqueue a redundant Set.
+func (c *Cache[K, V]) drainMissAndLookup(s *shard[K, V], kh uint64, key K) (*cacheItem[K, V], bool) {
+	if s.queue.quiescent() || !s.drainMu.TryLock() {
+		return nil, false
+	}
+	c.drainShardQueue(s)
+	s.drainMu.Unlock()
+	return s.tab.lookup(kh, key)
+}
+
 // drainShardQueue consumes read samples and queued writes. The caller must hold
 // s.drainMu so there is only one shard consumer.
 func (c *Cache[K, V]) drainShardQueue(s *shard[K, V]) {
@@ -401,93 +414,118 @@ func (c *Cache[K, V]) applyWriteBatch(s *shard[K, V], batch []writeCommand[K, V]
 	}
 }
 
-// newItem returns a pooled, populated item for cmd. acquireCacheItem zeroes the
-// node, so list links and lfuFreq start clean.
+// newItem allocates a populated item for cmd. Items are not pooled: lock-free
+// reads may hold an evicted item, so the GC owns reclamation. Zero-valued fields
+// (list links, visited) start clean.
 func (c *Cache[K, V]) newItem(cmd *writeCommand[K, V]) *cacheItem[K, V] {
-	item := acquireCacheItem[K, V](&c.itemPool)
-	item.value = cmd.value
-	item.lastAccess = cmd.now
-	item.key = cmd.key
-	item.hash = cmd.hash
-	item.expireTime = cmd.expireTime
-	item.cost = cmd.cost
-	return item
+	return &cacheItem[K, V]{
+		value:      cmd.value,
+		key:        cmd.key,
+		hash:       cmd.hash,
+		expireTime: cmd.expireTime,
+		cost:       cmd.cost,
+	}
 }
 
 // applySet mutates shard contents and policy state. The caller must hold s.mu.
 func (c *Cache[K, V]) applySet(s *shard[K, V], cmd *writeCommand[K, V]) bool {
-	cmdCost := cmd.cost
-	if ex, exists := s.data[cmd.key]; exists {
-		costDelta := cmdCost - ex.cost
-		ex.value = cmd.value
-		ex.lastAccess = cmd.now
-		ex.expireTime = cmd.expireTime
-		ex.hash = cmd.hash
-		if costDelta != 0 {
-			ex.cost = cmdCost
-			atomic.AddInt64(&s.cost, costDelta)
-		}
+	if c.config.EvictionPolicy == SieveTinyLFU && s.sieve != nil {
+		return c.applySieve(s, cmd)
+	}
 
-		switch c.config.EvictionPolicy {
-		case LRU:
-			s.moveToLRUHead(ex)
-		case LFU:
-			s.lfuList.remove(ex)
-			ex.lfuFreq = 1
-			s.lfuList.add(ex)
-		case SieveTinyLFU:
-			ex.lfuFreq = 0
-			if s.sieve != nil && !s.belowSieveWarmup() {
-				s.sieve.recordUpdate(ex)
-			}
+	// non-Sieve policies look up first so an existing key updates in place, and
+	// evict before inserting so the new item is not selected.
+	if ex, exists := s.tab.lookup(cmd.hash, cmd.key); exists {
+		return c.applyUpdate(s, cmd, ex)
+	}
+	for s.wouldOverCapacity(cmd.cost) && s.tab.length() > 0 {
+		c.evictor.evict(s, c.config.StatsEnabled)
+	}
+
+	item := c.newItem(cmd)
+	s.tab.store(item)
+	s.addToLRUHead(item)
+	if c.config.EvictionPolicy == LFU {
+		s.lfuList.add(item)
+	}
+	atomic.AddInt64(&s.size, 1)
+	if item.cost != 0 {
+		atomic.AddInt64(&s.cost, item.cost)
+	}
+	return true
+}
+
+// applySieve is the SieveTinyLFU write path. probe makes the insert/update
+// decision in one walk: an update swaps the new immutable item in place, while an
+// insert is published late. A new candidate runs admission while it is live in
+// the policy queues but absent from the table, so a rejected candidate is
+// unlinked policy-only and never touches the table (no store, no removeExact, no
+// tombstone) and is never visible to a lock-free Get. Only an admitted candidate
+// is published, at the slot probe located. Caller must hold s.mu.
+func (c *Cache[K, V]) applySieve(s *shard[K, V], cmd *writeCommand[K, V]) bool {
+	warmup := s.belowSieveWarmup()
+	item := c.newItem(cmd)
+	prev, cur := s.tab.probe(item)
+
+	if prev != nil {
+		// update: probe already swapped the slot to item; carry policy state across.
+		if d := cmd.cost - prev.cost; d != 0 {
+			atomic.AddInt64(&s.cost, d)
+		}
+		s.sieve.replaceNode(prev, item)
+		if !warmup {
+			s.sieve.recordUpdate(item)
 		}
 		c.enforcePostUpdateCapacity(s)
 		return true
 	}
 
-	if c.config.EvictionPolicy == SieveTinyLFU && s.sieve != nil {
-		warmup := s.belowSieveWarmup()
-		if !warmup {
-			s.sieve.recordAccess(cmd.hash)
-		}
-
-		item := c.newItem(cmd)
-		s.data[cmd.key] = item
-		atomic.AddInt64(&s.size, 1)
-		if item.cost != 0 {
-			atomic.AddInt64(&s.cost, item.cost)
-		}
-
-		ghostHit := !warmup && s.sieve.ghost.contains(cmd.hash)
-		s.sieve.insert(item, ghostHit)
-		if !warmup || s.overCapacity() {
-			s.enforceSieveCapacity(&c.itemPool, c.config.StatsEnabled, item, ghostHit)
-		}
-		if _, ok := s.data[cmd.key]; ok {
-			s.sieve.stats.Admits++
-			return true
-		}
-		s.sieve.stats.Rejects++
-		return false
+	// insert: hold the candidate out of the table until admission decides its fate.
+	item.unpublished = true
+	if !warmup {
+		s.sieve.recordAccess(cmd.hash)
 	}
-
-	// non-Sieve policies evict before inserting so the new item is not selected.
-	for s.wouldOverCapacity(cmdCost) && len(s.data) > 0 {
-		c.evictor.evict(s, &c.itemPool, c.config.StatsEnabled)
-	}
-
-	item := c.newItem(cmd)
-	s.data[cmd.key] = item
-	s.addToLRUHead(item)
-
-	if c.config.EvictionPolicy == LFU {
-		s.lfuList.add(item)
-	}
-
 	atomic.AddInt64(&s.size, 1)
 	if item.cost != 0 {
 		atomic.AddInt64(&s.cost, item.cost)
 	}
+	ghostHit := !warmup && s.sieve.ghost.contains(cmd.hash)
+	s.sieve.insert(item, ghostHit)
+	if !warmup || s.overCapacity() {
+		s.enforceSieveCapacity(c.config.StatsEnabled, item, ghostHit)
+	}
+	if s.sieve.owns(item) {
+		item.unpublished = false
+		s.tab.publish(item, cur)
+		s.sieve.stats.Admits++
+		return true
+	}
+	// rejected: enforceSieveCapacity already unlinked the candidate from policy and
+	// decremented size via the unpublished-aware drop; nothing was ever stored.
+	s.sieve.stats.Rejects++
+	return false
+}
+
+// applyUpdate updates an existing resident in place for LRU/LFU/FIFO, whose reads
+// hold the shard lock. SieveTinyLFU updates go through applySieve, which must
+// publish a fresh immutable item instead (a lock-free reader may hold the old
+// one). The caller must hold s.mu.
+func (c *Cache[K, V]) applyUpdate(s *shard[K, V], cmd *writeCommand[K, V], ex *cacheItem[K, V]) bool {
+	costDelta := cmd.cost - ex.cost
+	ex.value = cmd.value
+	ex.expireTime = cmd.expireTime
+	if costDelta != 0 {
+		ex.cost = cmd.cost
+		atomic.AddInt64(&s.cost, costDelta)
+	}
+	switch c.config.EvictionPolicy {
+	case LRU:
+		s.moveToLRUHead(ex)
+	case LFU:
+		s.lfuList.remove(ex)
+		s.lfuList.add(ex)
+	}
+	c.enforcePostUpdateCapacity(s)
 	return true
 }
 
@@ -498,17 +536,17 @@ func (c *Cache[K, V]) enforcePostUpdateCapacity(s *shard[K, V]) {
 		return
 	}
 	if c.config.EvictionPolicy == SieveTinyLFU && s.sieve != nil {
-		s.enforceSieveCapacity(&c.itemPool, c.config.StatsEnabled, nil, false)
+		s.enforceSieveCapacity(c.config.StatsEnabled, nil, false)
 		return
 	}
-	for s.overCapacity() && len(s.data) > 0 {
-		c.evictor.evict(s, &c.itemPool, c.config.StatsEnabled)
+	for s.overCapacity() && s.tab.length() > 0 {
+		c.evictor.evict(s, c.config.StatsEnabled)
 	}
 }
 
 // deleteKey removes key from a shard. The caller must hold s.mu.
-func (c *Cache[K, V]) deleteKey(s *shard[K, V], key K) bool {
-	item, exists := s.data[key]
+func (c *Cache[K, V]) deleteKey(s *shard[K, V], kh uint64, key K) bool {
+	item, exists := s.tab.lookup(kh, key)
 	if !exists {
 		return false
 	}
@@ -518,11 +556,10 @@ func (c *Cache[K, V]) deleteKey(s *shard[K, V], key K) bool {
 
 // clearShard resets a shard's contents and policy state. The caller must hold s.mu.
 func (c *Cache[K, V]) clearShard(s *shard[K, V]) {
-	for _, item := range s.data {
-		releaseCacheItem(&c.itemPool, item)
+	s.tab.clear()
+	if s.sieve == nil {
+		s.initLRU()
 	}
-	s.data = make(map[K]*cacheItem[K, V])
-	s.initLRU()
 	if c.config.EvictionPolicy == LFU {
 		s.lfuList = newLFUList[K, V]()
 	}
@@ -542,9 +579,10 @@ func (c *Cache[K, V]) scheduleCallback(task callbackTask[K, V]) {
 
 		select {
 		case <-timer.C:
-			s := c.getShard(task.key)
+			kh := c.hasher.Sum(task.key)
+			s := c.shardByHash(kh)
 			s.mu.RLock()
-			item, exists := s.data[task.key]
+			item, exists := s.tab.lookup(kh, task.key)
 			if exists && item.expireTime > 0 && time.Now().UnixNano() > item.expireTime {
 				s.mu.RUnlock()
 				task.callback(task.key, task.value)


### PR DESCRIPTION
- replace per-shard map storage with an open-addressed, single-writer/multi-reader hash table that enables lock-free bounded SieveTinyLFU reads.
- rework SieveTinyLFU insertion so new candidates are evaluated before table publication. Rejected candidates never become visible to readers.
- add opportunistic inline `SetAsync` when a shard is idle, plus miss-path queue catch-up for lock-free reads racing queued writes.
- optimize policy maintenance with indexed ghost queues, striped stats counters, immutable reader-visible items and expanded htable/Sieve/ghost tests.
- `SetAsync` may now commit inline and be immediately visible when the shard is uncontended. A nil error still means the write was accepted. Callers should use `Sync()` when committed visibility is required.
- the default per-shard async write buffer is now 256.